### PR TITLE
Fix use of HASH_FIND() in RemoveScreenPointerMapping()

### DIFF
--- a/src/GLX/libglxmapping.c
+++ b/src/GLX/libglxmapping.c
@@ -563,7 +563,7 @@ static void RemoveScreenPointerMapping(void *ptr, int screen)
 
     LKDHASH_WRLOCK(__glXPthreadFuncs, __glXScreenPointerMappingHash);
 
-    HASH_FIND(hh, _LH(__glXScreenPointerMappingHash), ptr, sizeof(ptr), pEntry);
+    HASH_FIND_PTR(_LH(__glXScreenPointerMappingHash), &ptr, pEntry);
 
     if (pEntry != NULL) {
         HASH_DELETE(hh, _LH(__glXScreenPointerMappingHash), pEntry);
@@ -581,7 +581,7 @@ static int ScreenFromPointer(void *ptr)
 
     LKDHASH_RDLOCK(__glXPthreadFuncs, __glXScreenPointerMappingHash);
 
-    HASH_FIND(hh, _LH(__glXScreenPointerMappingHash), &ptr, sizeof(ptr), pEntry);
+    HASH_FIND_PTR(_LH(__glXScreenPointerMappingHash), &ptr, pEntry);
 
     if (pEntry != NULL) {
         screen = pEntry->screen;


### PR DESCRIPTION
Replace HASH_FIND() with the convenience macro HASH_FIND_PTR() in
RemoveScreenPointerMapping() and ScreenFromPointer(), to be consistent
with AddScreenPointerMapping().  This has the side-effect of fixing
invalid usage of the original HASH_FIND() macro in
RemoveScreenPointerMapping().

Signed-Off-By: Brian Nguyen brnguyen@nvidia.com
Fixes #3
