### PR TITLE
[build] fix more srcdir != builddir mistakes

### DIFF
--- a/src/OpenGL/Makefile.am
+++ b/src/OpenGL/Makefile.am
@@ -41,7 +41,7 @@ glapitemp.h : $(GLAPI)/gen/gl_and_es_API.xml $(glapi_gen_mapi_deps)
 	$(call glapi_gen_mapi,$<,noop-gl)
 
 libOpenGL_la_CFLAGS = \
-	-I$(top_builddir)/include
+	-I$(top_srcdir)/include
 
 libOpenGL_la_LDFLAGS = -shared -Wl,--auxiliary=libGLdispatch.so.0
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -61,16 +61,16 @@ testglxnscreens_SOURCES = \
 	testglxnscreens.c \
 	test_utils.c
 
-X11GLVND_DIR = $(top_builddir)/src/x11glvnd
+X11GLVND_DIR = src/x11glvnd
 
-testglxnscreens_CFLAGS = -I$(X11GLVND_DIR) $(AM_CFLAGS)
+testglxnscreens_CFLAGS = -I$(top_srcdir)/$(X11GLVND_DIR) $(AM_CFLAGS)
 
 testglxnscreens_LDADD = -lX11
 testglxnscreens_LDADD += $(top_builddir)/src/GLX/libGLX.la
 testglxnscreens_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
 testglxnscreens_LDADD += $(top_builddir)/src/util/glvnd_pthread/libglvnd_pthread.la
 testglxnscreens_LDADD += $(top_builddir)/src/util/trace/libtrace.la
-testglxnscreens_LDADD += -lX11 $(X11GLVND_DIR)/libx11glvnd_client.la
+testglxnscreens_LDADD += -lX11 $(top_builddir)/$(X11GLVND_DIR)/libx11glvnd_client.la
 
 # The *_oldlink variant tests that linking against legacy libGL.so works
 
@@ -89,17 +89,17 @@ testglxmakecurrent_oldlink_LDADD += $(top_builddir)/src/GL/libGL.la
 testglxmakecurrent_oldlink_LDADD += $(top_builddir)/src/util/glvnd_pthread/libglvnd_pthread.la
 testglxmakecurrent_oldlink_LDADD += $(top_builddir)/src/util/trace/libtrace.la
 
-testx11glvndproto_CFLAGS = -I$(X11GLVND_DIR)
-testx11glvndproto_LDADD = -lX11 $(X11GLVND_DIR)/libx11glvnd_client.la
+testx11glvndproto_CFLAGS = -I$(top_srcdir)/$(X11GLVND_DIR)
+testx11glvndproto_LDADD = -lX11 $(top_builddir)/$(X11GLVND_DIR)/libx11glvnd_client.la
 
 # Disable annoying "unused" errors
 AM_CFLAGS =                                  \
 	-Wno-error=unused-variable               \
 	-Wno-error=unused-label                  \
-	-I$(top_builddir)/include                \
-	-I$(top_builddir)/src/util               \
-	-I$(top_builddir)/src/util/trace         \
-	-I$(top_builddir)/src/util/glvnd_pthread
+	-I$(top_srcdir)/include                  \
+	-I$(top_srcdir)/src/util                 \
+	-I$(top_srcdir)/src/util/trace           \
+	-I$(top_srcdir)/src/util/glvnd_pthread
 
 
 testglxgetprocaddress_LDADD = $(top_builddir)/src/GLX/libGLX.la


### PR DESCRIPTION
I missed these in commit debae590e724ee064939982bd3f54a613d5fa650 for issue #2
because my test system had a compatible glxext.h in /usr/include/GL.  On a
system with an incompatible version (i.e. Ubuntu), this causes build failures.
Fix the include paths to include the GL headers from the repository instead of
the system.

Signed-off-by: Aaron Plattner aplattner@nvidia.com
