### PR TITLE
[build] enable silent rules by default

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -83,7 +83,7 @@ if [ "x$AUTOCONF_VERSION" = "x" ] ; then
 fi
 # set to minimum acceptable version of automake
 if [ "x$AUTOMAKE_VERSION" = "x" ] ; then
-    AUTOMAKE_VERSION=1.6.0
+    AUTOMAKE_VERSION=1.11.0
 fi
 # set to minimum acceptable version of libtool
 if [ "x$LIBTOOL_VERSION" = "x" ] ; then

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,8 @@ AC_CANONICAL_SYSTEM
 
 AC_USE_SYSTEM_EXTENSIONS
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([1.11 foreign silent-rules])
+AM_SILENT_RULES([yes])
 
 dnl Checks for programs.
 AC_PROG_AWK


### PR DESCRIPTION
Brian, what do you think of enabling automake's silent rules by default?  With this change I just bumped the minimum required automake to 1.11 since I don't really want to have to test it with older automakes, but I can also use m4_ifdef to only enable it if AM_SILENT_RULES exists.
