### PR TITLE
[tests] Replace SKIP_ENV_INIT with DO_X11_TESTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ There are a few good starting points for familiarizing oneself with the code:
 
 The tests/ directory contains several unit tests which verify that dispatching
 to different vendors actually works. Run `make check` to run these unit tests.
-Note some of the unit tests require a special environment that can only be set
-up if X is not currently running. To skip these tests (and environment
-initialization/teardown), run `make check SKIP_ENV_INIT=1`.
+Note some of the unit tests require a special X server configuration and
+are skipped by default.  To include these tests (and X server
+initialization/teardown), run `make check DO_X11_TESTS=1`.
 
 Architecture
 ------------

--- a/tests/fini_test_env.sh
+++ b/tests/fini_test_env.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -n "$SKIP_ENV_INIT" ]; then
+if [ -z "$DO_X11_TESTS" ]; then
     echo "Test environment cleanup skipped"
     exit 77
 fi

--- a/tests/init_test_env.sh
+++ b/tests/init_test_env.sh
@@ -2,11 +2,11 @@
 
 echo -n "Initializing test environment... "
 
-if [ -n "$SKIP_ENV_INIT" ]; then
+if [ -z "$DO_X11_TESTS" ]; then
     echo "skipped"
     exit 77
 fi
-echo "(set SKIP_ENV_INIT to disable this step)"
+echo "(unset DO_X11_TESTS to disable this step)"
 
 X -config "$ABS_TOP_BUILDDIR/tests/xorg.2screens.conf" \
   -modulepath "/usr/lib/xorg/modules/,$ABS_TOP_BUILDDIR/src/x11glvnd/.libs" \

--- a/tests/testglxnscreens.sh
+++ b/tests/testglxnscreens.sh
@@ -2,7 +2,7 @@
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TOP_BUILDDIR/tests/GLX_dummy/.libs
 
-if [ -n "$SKIP_ENV_INIT" ]; then
+if [ -z "$DO_X11_TESTS" ]; then
     echo "Skipping test; requires environment init"
     exit 77
 fi

--- a/tests/testglxnscrthreads.sh
+++ b/tests/testglxnscrthreads.sh
@@ -5,7 +5,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TOP_BUILDDIR/tests/GLX_dummy/.libs
 # We require pthreads be loaded before libGLX for correctness
 export LD_PRELOAD=libpthread.so.0
 
-if [ -n "$SKIP_ENV_INIT" ]; then
+if [ -z "$DO_X11_TESTS" ]; then
     echo "Skipping test; requires environment init"
     exit 77
 fi

--- a/tests/testx11glvndproto.sh
+++ b/tests/testx11glvndproto.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -n "$SKIP_ENV_INIT" ]; then
+if [ -z "$DO_X11_TESTS" ]; then
     echo "Skipping test; requires environment init"
     exit 77
 fi


### PR DESCRIPTION
Instead of requiring a special environment variable to skip tests
which require a special X11 environment, skip these tests by default
and have users opt-in with the DO_X11_TESTS environment variable.

This (finally) fixes "make distcheck".
