### PR TITLE
Pull core GL dispatch management out of libglxabi.h

### DIFF
--- a/src/GLX/libglxabi.h
+++ b/src/GLX/libglxabi.h
@@ -33,6 +33,8 @@
 #include <stdint.h>
 #include <GL/glx.h>
 
+#include "GLdispatchABI.h"
+
 /*!
  * \defgroup glxvendorabi GLX Vendor ABI
  *
@@ -67,11 +69,6 @@
  * functions retrieve and operate on this structure using the API below.
  */
 typedef struct __GLXdispatchTableDynamicRec __GLXdispatchTableDynamic;
-
-/*!
- * This opaque structure describes the core GL dispatch table.
- */
-typedef struct __GLXcoreDispatchTableRec __GLXcoreDispatchTable;
 
 /*!
  * Forward declaration for createGLDispatch export.
@@ -120,70 +117,10 @@ typedef struct __GLXapiExportsRec {
     GLXContext                (*getCurrentContext)(void);
 
     /************************************************************************
-     * When a context is current, for performance reasons it may be desirable
-     * for a vendor to use different entrypoints for that context depending on
-     * the current GL state. The following routines allow a vendor to create and
-     * manage auxiliary dispatch tables for this purpose.
+     * This structure stores procs for managing core GL dispatch tables.
      ************************************************************************/
 
-    /*!
-     * This retrieves the current core GL dispatch table.
-     */
-    __GLXcoreDispatchTable    *(*getCurrentGLDispatch)(void);
-
-    /*!
-     * This retrieves the top-level GL dispatch table for the current vendor.
-     * This must always be defined for the lifetime of the vendor library.
-     */
-    __GLXcoreDispatchTable     *(*getTopLevelDispatch)(void);
-
-    /*!
-     * This creates an auxiliary core GL dispatch table using the given
-     * vendor-specific callbacks and data. This data will be passed to the
-     * getProcAddress callback during dispatch table construction and can be
-     * used to discriminate between different flavors of entrypoints in the
-     * vendor.
-     * XXX: is the getProcAddress callback method too slow? Should we have
-     * a way for vendor libraries to declare fixed tables at startup that
-     * can be read quickly?
-     */
-    __GLXcoreDispatchTable   *(*createGLDispatch)(
-        const __GLXvendorCallbacks *cb,
-        void *data
-    );
-
-    /*!
-     * This retrieves the offset into the GL dispatch table for the given
-     * function name, or -1 if the function is not found.
-     * If a valid offset is returned, the offset is valid for all dispatch
-     * tables for the lifetime of the API library.
-     * XXX: should there be a way for vendor libraries to pre-load procs
-     * they care about?
-     */
-    GLint (*getGLDispatchOffset)(const GLubyte *procName);
-
-    /*!
-     * This sets the given entry in the GL dispatch table to the function
-     * address pointed to by addr.
-     */
-    void (*setGLDispatchEntry)(__GLXcoreDispatchTable *table,
-                               GLint offset,
-                               __GLXextFuncPtr addr);
-
-    /*!
-     * This makes the given GL dispatch table current. Note this operation
-     * is only valid when there is a GL context owned by the vendor which
-     * is current.
-     */
-    void (*makeGLDispatchCurrent)(__GLXcoreDispatchTable *table);
-
-    /*!
-     * This destroys the given GL dispatch table, and returns GL_TRUE on
-     * success. Note it is an error to attempt to destroy the top-level
-     * dispatch.
-     */
-    GLboolean (*destroyGLDispatch)(__GLXcoreDispatchTable *table);
-
+    __GLdispatchExports glde;
 } __GLXapiExports;
 
 /*****************************************************************************

--- a/src/GLX/libglxgldispatch.h
+++ b/src/GLX/libglxgldispatch.h
@@ -32,21 +32,6 @@
 
 #include "libglxabi.h"
 
-/*
- * These functions define the interface by which a vendor library can install
- * and manage its own collection of dispatch tables. See libglxabi.h for
- * a more detailed explanation of these functions.
- */
-
-__GLXcoreDispatchTable *__glXGetCurrentGLDispatch(void);
-__GLXcoreDispatchTable *__glXGetTopLevelDispatch(void);
-__GLXcoreDispatchTable *__glXCreateGLDispatch(const __GLXvendorCallbacks *cb,
-                                              void *data);
-GLint __glXGetGLDispatchOffset(const GLubyte *procName);
-void __glXSetGLDispatchEntry(__GLXcoreDispatchTable *table,
-                             GLint offset,
-                             __GLXextFuncPtr addr);
-void __glXMakeGLDispatchCurrent(__GLXcoreDispatchTable *table);
-GLboolean __glXDestroyGLDispatch(__GLXcoreDispatchTable *table);
+extern __GLdispatchExports __glXGLdispatchExportsTable;
 
 #endif // __LIBGLX_GL_DISPATCH_H__

--- a/src/GLX/libglxnoopdefs.h
+++ b/src/GLX/libglxnoopdefs.h
@@ -35,9 +35,6 @@
  * libglxnoop.c and the libGL filter library code.
  */
 
-#include "libglxabipriv.h"
-#include "libglxnoop.h"
-
 GLXNOOP XVisualInfo* NOOP_FUNC(ChooseVisual)(Display *dpy, int screen,
                                           int *attrib_list)
 {

--- a/src/GLdispatch/GLdispatch.c
+++ b/src/GLdispatch/GLdispatch.c
@@ -305,9 +305,9 @@ PUBLIC void __glDispatchSetEntry(__GLdispatchTable *dispatch,
     UnlockDispatch();
 }
 
-GLint __glDispatchGetOffset(const char *procName)
+GLint __glDispatchGetOffset(const GLubyte *procName)
 {
-    return _glapi_get_proc_offset(procName);
+    return _glapi_get_proc_offset((const char *)procName);
 }
 
 PUBLIC __GLdispatchTable *__glDispatchCreateTable(__GLgetProcAddressCallback getProcAddress,

--- a/src/GLdispatch/GLdispatch.h
+++ b/src/GLdispatch/GLdispatch.h
@@ -33,6 +33,7 @@
 #include "glheader.h"
 #include "compiler.h"
 #include "glvnd_pthread.h"
+#include "GLdispatchABI.h"
 
 /*!
  * \defgroup gldispatch core GL/GLES dispatch and TLS module
@@ -52,19 +53,6 @@
 #define CURRENT_API_STATE   2  // GLAPI_CURRENT_USER1
 
 PUBLIC void *_glapi_get_current(int index);
-
-typedef void (*__GLdispatchProc)(void);
-typedef void *(*__GLgetProcAddressCallback)(const GLubyte *procName,
-                                            void *vendorData);
-typedef void *(*__GLgetProcAddressCallback)(const GLubyte *procName,
-                                            void *vendorData);
-typedef GLboolean (*__GLgetDispatchProtoCallback)(const GLubyte *procName,
-                                                  char ***function_names,
-                                                  char **parameter_signature);
-typedef void (*__GLdestroyVendorDataCallback)(void *vendorData);
-
-/* Opaque dispatch table structure. */
-typedef struct __GLdispatchTableRec __GLdispatchTable;
 
 /* Namespaces for API state */
 enum {
@@ -184,7 +172,7 @@ static inline void *__glDispatchGetCurrentContext(void)
  * describes a real offset.  If the call succeeds, the offset remains valid for
  * the lifetime of libglvnd for all GL dispatch tables used by libglvnd.
  */
-PUBLIC GLint __glDispatchGetOffset(const char *procName);
+PUBLIC GLint __glDispatchGetOffset(const GLubyte *procName);
 
 /*!
  * This sets the dispatch table entry given by <offset> to the entrypoint

--- a/src/GLdispatch/GLdispatchABI.h
+++ b/src/GLdispatch/GLdispatchABI.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2013, NVIDIA CORPORATION.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and/or associated documentation files (the
+ * "Materials"), to deal in the Materials without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Materials, and to
+ * permit persons to whom the Materials are furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * unaltered in all copies or substantial portions of the Materials.
+ * Any additions, deletions, or changes to the original source files
+ * must be clearly indicated in accompanying documentation.
+ *
+ * If only executable code is distributed, then the accompanying
+ * documentation must state that "this software is based in part on the
+ * work of the Khronos Group."
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+ */
+
+#include <GL/gl.h>
+
+#if !defined(__GL_DISPATCH_ABI_H)
+#define __GL_DISPATCH_ABI_H
+
+/*!
+ * \defgroup gldispatchabi GL dispatching ABI
+ *
+ * This is not a complete ABI, but rather a fragment common to the libEGL and
+ * libGLX ABIs.  Changes to this file should be accompanied by a version bump to
+ * these client ABIs.
+ */
+
+/*!
+ * This opaque structure describes the core GL dispatch table.
+ */
+typedef struct __GLdispatchTableRec __GLdispatchTable;
+
+typedef void (*__GLdispatchProc)(void);
+
+typedef void *(*__GLgetProcAddressCallback)(const GLubyte *procName,
+                                            void *vendorData);
+
+typedef void *(*__GLgetProcAddressCallback)(const GLubyte *procName,
+                                            void *vendorData);
+
+typedef GLboolean (*__GLgetDispatchProtoCallback)(const GLubyte *procName,
+                                                  char ***function_names,
+                                                  char **parameter_signature);
+
+typedef void (*__GLdestroyVendorDataCallback)(void *vendorData);
+
+
+
+typedef struct __GLdispatchExportsRec {
+    /************************************************************************
+     * When a context is current, for performance reasons it may be desirable
+     * for a vendor to use different entrypoints for that context depending on
+     * the current GL state. The following routines allow a vendor to create and
+     * manage auxiliary dispatch tables for this purpose.
+     ************************************************************************/
+
+    /*!
+     * This retrieves the current core GL dispatch table.
+     */
+    __GLdispatchTable    *(*getCurrentGLDispatch)(void);
+
+    /*!
+     * This retrieves the top-level GL dispatch table for the current vendor.
+     * This must always be defined for the lifetime of the vendor library.
+     */
+    __GLdispatchTable     *(*getTopLevelDispatch)(void);
+
+    /*!
+     * This creates an auxiliary core GL dispatch table using the given
+     * vendor-specific callbacks and data. This data will be passed to the
+     * getProcAddress callback during dispatch table construction and can be
+     * used to discriminate between different flavors of entrypoints in the
+     * vendor.
+     * XXX: is the getProcAddress callback method too slow? Should we have
+     * a way for vendor libraries to declare fixed tables at startup that
+     * can be read quickly?
+     */
+    __GLdispatchTable   *(*createGLDispatch)(
+        __GLgetProcAddressCallback getProcAddress,
+        __GLgetDispatchProtoCallback getDispatchProto,
+        __GLdestroyVendorDataCallback destroyVendorData,
+        void *vendorData
+    );
+
+    /*!
+     * This retrieves the offset into the GL dispatch table for the given
+     * function name, or -1 if the function is not found.
+     * If a valid offset is returned, the offset is valid for all dispatch
+     * tables for the lifetime of the API library.
+     * XXX: should there be a way for vendor libraries to pre-load procs
+     * they care about?
+     */
+    GLint (*getGLDispatchOffset)(const GLubyte *procName);
+
+    /*!
+     * This sets the given entry in the GL dispatch table to the function
+     * address pointed to by addr.
+     */
+    void (*setGLDispatchEntry)(__GLdispatchTable *table,
+                               GLint offset,
+                               __GLdispatchProc addr);
+
+    /*!
+     * This makes the given GL dispatch table current. Note this operation
+     * is only valid when there is a GL context owned by the vendor which
+     * is current.
+     */
+    void (*makeGLDispatchCurrent)(__GLdispatchTable *table);
+
+    /*!
+     * This destroys the given GL dispatch table, and returns GL_TRUE on
+     * success. Note it is an error to attempt to destroy the top-level
+     * dispatch.
+     */
+    GLboolean (*destroyGLDispatch)(__GLdispatchTable *table);
+
+} __GLdispatchExports;
+
+
+#endif // __GL_DISPATCH_ABI_H

--- a/tests/GLX_dummy/Makefile.am
+++ b/tests/GLX_dummy/Makefile.am
@@ -11,8 +11,9 @@ libGLX_dummy_copy : libGLX_dummy.la
 	cp .libs/libGLX_dummy.so.0.0.0 .libs/libGLX_dummy_1.so.0
 
 
-libGLX_dummy_la_CFLAGS =             \
+libGLX_dummy_la_CFLAGS =           \
 	-I$(top_srcdir)/src/GLX        \
+	-I$(top_srcdir)/src/GLdispatch \
 	-I$(top_srcdir)/src/util       \
 	-I$(top_srcdir)/src/util/trace \
 	-I$(top_srcdir)/include        \


### PR DESCRIPTION
Move the relevant function exports into a separate file,
GLdispatchABI.h, which is included by libglxabi.h.  This file uses
native GLdispatch types, and defines a separate __GLdispatchExports
struct which is added as a field to __GLXapiexports.  This allows us to
do some additional cleanup:
- In libglxgldispatch.c, remove wrapper functions and
  make remaining wrapper functions static.  Now glxgldispatch.h
  defines a single __GLdispatchExports table.
- In libglxmappings.c, replace static initialization of glxExportsTable
  with one-time runtime initialization of the table.  This copies
  the table defined in glxgldispatch.h to glxExportsTable at the
  appropriate time.
- In libglxmappings.c, use __glDispatchCreateTable() directly to create
  the initial dispatch table.
- In libglxnoopdefs.h, remove unnecessary includes of libglxabipriv.h
  and libglxnoop.h.

Signed-Off-By: Brian Nguyen brnguyen@nvidia.com
