### PR TITLE
makecurrent fixes

### DIFF
--- a/src/GLX/libglx.c
+++ b/src/GLX/libglx.c
@@ -457,65 +457,10 @@ static Bool IsContextCurrentToAnyOtherThread(GLXContext ctx)
     return !!pEntry && (current != ctx);
 }
 
-/*!
- * Given the Make{Context,}Current arguments passed in, tries to find the
- * screen of an appropriate vendor to notify when an X error occurs.  It's
- * possible none of the arguments in this list will produce a valid screen
- * number, so this will fall back to screen 0 if all else fails.
- */
-int FindAnyValidScreenFromMakeCurrent(Display *dpy,
-                                      GLXDrawable draw,
-                                      GLXDrawable read,
-                                      GLXContext context)
-{
-    int screen;
-
-    screen = __glXScreenFromContext(__glXGetCurrentContext());
-
-    if (screen < 0) {
-        screen = __glXScreenFromContext(context);
-    }
-
-    if (screen < 0) {
-        screen = __glXScreenFromDrawable(dpy, draw);
-    }
-
-    if (screen < 0) {
-        screen = __glXScreenFromDrawable(dpy, read);
-    }
-
-    if (screen < 0) {
-        /* If no screens were found, fall back to 0 */
-        screen = 0;
-    }
-
-    return screen;
-}
-
-void NotifyVendorOfXError(int screen,
-                          Display *dpy,
-                          char errorOpcode,
-                          char minorOpcode,
-                          XID resid)
-{
-    /*
-     * XXX: For now, libglvnd doesn't handle generating X errors directly.
-     * Instead, it tries to pass the error off to an available vendor library
-     * so the vendor can handle generating the X error.
-     */
-    const __GLXdispatchTableStatic *pDispatch =
-        __glXGetStaticDispatch(dpy, screen);
-
-    if (pDispatch->glxvc.notifyError) {
-        pDispatch->glxvc.notifyError(dpy, errorOpcode, minorOpcode, resid);
-    }
-}
-
 static Bool MakeContextCurrentInternal(Display *dpy,
                                        GLXDrawable draw,
                                        GLXDrawable read,
                                        GLXContext context,
-                                       char callerOpcode,
                                        const __GLXdispatchTableStatic **ppDispatch)
 {
     __GLXAPIState *apiState;
@@ -525,9 +470,6 @@ static Bool MakeContextCurrentInternal(Display *dpy,
 
     DBG_PRINTF(0, "dpy = %p, draw = %x, read = %x, context = %p\n",
                dpy, (unsigned)draw, (unsigned)read, context);
-
-    assert(callerOpcode == X_GLXMakeCurrent ||
-           callerOpcode == X_GLXMakeContextCurrent);
 
     apiState = __glXGetCurrentAPIState();
     oldVendor = apiState->currentVendor;
@@ -541,20 +483,6 @@ static Bool MakeContextCurrentInternal(Display *dpy,
          * context again.  This is incorrect application behavior, but we should
          * attempt to handle this failure gracefully.
          */
-        return False;
-    }
-
-    if ((!context && (draw != None || read != None)) ||
-        (context && (draw == None || read == None))) {
-        int errorScreen =
-            FindAnyValidScreenFromMakeCurrent(dpy, draw, read, context);
-        /*
-         * If <ctx> is NULL and <draw> and <read> are not None, or
-         * if <draw> or <read> are set to None and <ctx> is not NULL,
-         * then a BadMatch error will be generated. GLX 1.4 section 3.3.7
-         * (p. 27).
-         */
-        NotifyVendorOfXError(errorScreen, dpy, BadMatch, callerOpcode, 0);
         return False;
     }
 
@@ -585,6 +513,10 @@ static Bool MakeContextCurrentInternal(Display *dpy,
     *ppDispatch = newVendor ? newVendor->staticDispatch : NULL;
 
     if (!context) {
+        if (draw != None || read != None) {
+            return False;
+        }
+
         /*
          * Call into GLdispatch to lose current and update the context and GL
          * dispatch table
@@ -687,7 +619,6 @@ PUBLIC Bool glXMakeCurrent(Display *dpy, GLXDrawable drawable, GLXContext contex
                                      drawable,
                                      drawable,
                                      context,
-                                     X_GLXMakeCurrent,
                                      &pDispatch);
     if (ret) {
         assert(!context || pDispatch);
@@ -695,19 +626,18 @@ PUBLIC Bool glXMakeCurrent(Display *dpy, GLXDrawable drawable, GLXContext contex
             ret = pDispatch->glx14ep.makeCurrent(dpy, drawable, context);
             if (!ret) {
                 // Restore the original current values
-                tmpRet = MakeContextCurrentInternal(dpy,
-                                                    oldDraw,
-                                                    oldRead,
-                                                    oldContext,
-                                                    X_GLXMakeCurrent,
-                                                    &pDispatch);
-                assert(tmpRet);
+                ret = MakeContextCurrentInternal(dpy,
+                                                 oldDraw,
+                                                 oldRead,
+                                                 oldContext,
+                                                 &pDispatch);
+                assert(ret);
                 if (pDispatch) {
-                    tmpRet = pDispatch->glx14ep.makeContextCurrent(dpy,
+                    ret = pDispatch->glx14ep.makeContextCurrent(dpy,
                                                                 oldDraw,
                                                                 oldRead,
                                                                 oldContext);
-                    assert(tmpRet);
+                    assert(ret);
                 }
             }
         }
@@ -1149,7 +1079,6 @@ PUBLIC Bool glXMakeContextCurrent(Display *dpy, GLXDrawable draw,
                                      draw,
                                      read,
                                      context,
-                                     X_GLXMakeContextCurrent,
                                      &pDispatch);
     if (ret) {
         assert(!context || pDispatch);
@@ -1160,19 +1089,18 @@ PUBLIC Bool glXMakeContextCurrent(Display *dpy, GLXDrawable draw,
                                                         context);
             if (!ret) {
                 // Restore the original current values
-                tmpRet = MakeContextCurrentInternal(dpy,
-                                                    oldDraw,
-                                                    oldRead,
-                                                    oldContext,
-                                                    X_GLXMakeContextCurrent,
-                                                    &pDispatch);
-                assert(tmpRet);
+                ret = MakeContextCurrentInternal(dpy,
+                                                 oldDraw,
+                                                 oldRead,
+                                                 oldContext,
+                                                 &pDispatch);
+                assert(ret);
                 if (pDispatch) {
-                    tmpRet = pDispatch->glx14ep.makeContextCurrent(dpy,
+                    ret = pDispatch->glx14ep.makeContextCurrent(dpy,
                                                                 oldDraw,
                                                                 oldRead,
                                                                 oldContext);
-                    assert(tmpRet);
+                    assert(ret);
                 }
             }
         }

--- a/src/GLX/libglxabi.h
+++ b/src/GLX/libglxabi.h
@@ -295,13 +295,6 @@ struct __GLXvendorCallbacksRec {
     void        (*setDispatchIndex)      (const GLubyte *procName, int index);
 
     /*!
-     * This notifies the vendor library when an X error should be generated
-     * due to a detected error in the GLX API stream.
-     */
-    void        (*notifyError)  (Display *dpy, char error,
-                                 char opcode, XID resid);
-
-    /*!
      * (OPTIONAL) Callbacks by which the vendor library may re-write libglvnd's
      * entrypoints at make current time, provided no other contexts are current
      * and the TLS model supports this functionality.  This is a performance


### PR DESCRIPTION
Hey, I'm working on wiring Mesa up to libglvnd. I found a couple of issues in how libGLX handles MakeCurrent that I think would be regressions from current libGLs.  I've tried to make the commit messages self-explanitory, let me know if I can answer any questions.