### PR TITLE
[GLdispatchABI.h] Add a new releasePatch() entrypoint patching callback

### DIFF
--- a/src/GLdispatch/GLdispatch.c
+++ b/src/GLdispatch/GLdispatch.c
@@ -578,6 +578,12 @@ static int PatchEntrypoints(
         return 1;
     }
 
+    if (stubCurrentPatchCb) {
+        // Notify the previous vendor that it no longer owns these
+        // entrypoints.
+        stubCurrentPatchCb->releasePatch();
+    }
+
     if (patchCb) {
         GLboolean needOffsets;
 

--- a/src/GLdispatch/GLdispatchABI.h
+++ b/src/GLdispatch/GLdispatchABI.h
@@ -87,10 +87,19 @@ typedef struct __GLdispatchPatchCallbacksRec {
     void (*getOffsetHook)(void *(*lookupStubOffset)(const char *funcName));
 
     /*
-     * Called by libglvnd to finish the top-level entrypoint patch.  libglvnd
-     * must have called the __GLdispatchInitiatePatch callback first!
+     * Called by libglvnd to finish the initial top-level entrypoint patch.
+     * libglvnd must have called the __GLdispatchInitiatePatch callback first!
+     * After this function is called, the vendor "owns" the top-level
+     * entrypoints and may change them at will until GLdispatch calls the
+     * releasePatch callback below.
      */
     void (*finalizePatch)(void);
+
+    /*
+     * Called by libglvnd to notify the current vendor that it no longer owns
+     * the top-level entrypoints.
+     */
+    void (*releasePatch)(void);
 } __GLdispatchPatchCallbacks;
 
 #if defined(__cplusplus)


### PR DESCRIPTION
This callback notifies vendors when they no longer "own" patched
top-level libglvnd entrypoints.  This allows vendors to safely
take advantage of optimizations which may modify entrypoint code
outside of the finalizePatch() callback.