### PR TITLE
WIP support for fedora 20/21

### DIFF
--- a/10-x11glvnd.conf
+++ b/10-x11glvnd.conf
@@ -1,0 +1,5 @@
+#This file is provided by libglvnd
+
+Section "Module"
+Load "x11glvnd"
+EndSection

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,12 @@
 SUBDIRS = src tests
 noinst_HEADERS = include
 ACLOCAL_AMFLAGS = -I m4
+
+if HAVE_XORG_SUBDIR
+sysconfig_DATA = \
+        10-x11glvnd.conf
+endif
+
+EXTRA_DIST = 10-x11glvnd.conf
+
+AM_DISTCHECK_CONFIGURE_FLAGS = sysconfigdir=\$${datarootdir}/X11/xorg.conf.d

--- a/configure.ac
+++ b/configure.ac
@@ -128,6 +128,14 @@ if test "x$enable_asm" = xyes; then
     esac
 fi
 
+dnl Test X.Org X server sysconfigdir variable
+AC_MSG_CHECKING([for X.Org X server sysconfigdir variable])
+PKG_CHECK_VAR([sysconfigdir], [xorg-server], [sysconfigdir])
+AC_MSG_RESULT([$sysconfigdir])
+AC_SUBST([sysconfigdir])
+
+AM_CONDITIONAL([HAVE_XORG_SUBDIR], [])
+
 dnl Various conditionals.
 AM_CONDITIONAL([GCC], [test x$GCC = xyes ])
 

--- a/src/x11glvnd/x11glvndserver.c
+++ b/src/x11glvnd/x11glvndserver.c
@@ -92,7 +92,11 @@ static ExtensionModule glvExtensionModule = {
 static XF86ModuleVersionInfo x11glvndVersionInfo =
 {
     "x11glvnd",
+#ifdef XVENDORNAME
+    XVENDORNAME,
+#else
     "NVIDIA Corporation",
+#endif
     MODINFOSTRING1,
     MODINFOSTRING2,
     XORG_VERSION_NUMERIC(4,0,2,0,0),

--- a/src/x11glvnd/x11glvndserver.c
+++ b/src/x11glvnd/x11glvndserver.c
@@ -54,6 +54,8 @@ typedef struct XGLVScreenPrivRec {
 
 DevPrivateKeyRec glvXGLVScreenPrivKey;
 
+#define XGLV_ABI_HAS_LOAD_EXTENSION_LIST \
+    (GET_ABI_MAJOR(ABI_VIDEODRV_VERSION) >= 17)
 #define XGLV_SET_SCREEN_PRIVATE(pScreen, priv) \
     dixSetPrivate(&(pScreen)->devPrivates, &glvXGLVScreenPrivKey, priv)
 #define XGLV_SCREEN_PRIVATE(pScreen) \
@@ -128,7 +130,11 @@ static void *glvSetup(void *module, void *opts, int *errmaj, int *errmin)
         return NULL;
     }
 
+#if XGLV_ABI_HAS_LOAD_EXTENSION_LIST
+    LoadExtensionList(&glvExtensionModule, 1, False);
+#else
     LoadExtension(&glvExtensionModule, False);
+#endif
 
     return (pointer)1;
 }


### PR DESCRIPTION
Hello,

This is an attempt to play with libglvnd on fedora 20/21 with RPM Fusion packaged drivers.
Currently I cannot replace mesa-libGL on optimus device, probably because fedora mesa is built with tls support enabled
This may explain issue like this:
(EE) AIGLX error: dlopen of /usr/lib64/dri/i965_dri.so failed (/usr/lib64/dri/i965_dri.so: undefined symbol: _glapi_tls_
(EE) AIGLX: reverting to software rendering
(EE) GLX: could not load software renderer
(II) GLX: no usable GL providers found for screen 0

Thx