### PR TITLE
Support for xorg-server 1.16

### DIFF
--- a/10-x11glvnd.conf
+++ b/10-x11glvnd.conf
@@ -1,0 +1,5 @@
+#This file is provided by libglvnd
+
+Section "Module"
+Load "x11glvnd"
+EndSection

--- a/src/x11glvnd/x11glvndserver.c
+++ b/src/x11glvnd/x11glvndserver.c
@@ -92,7 +92,11 @@ static ExtensionModule glvExtensionModule = {
 static XF86ModuleVersionInfo x11glvndVersionInfo =
 {
     "x11glvnd",
+#ifdef XVENDORNAME
+    XVENDORNAME,
+#else
     "NVIDIA Corporation",
+#endif
     MODINFOSTRING1,
     MODINFOSTRING2,
     XORG_VERSION_NUMERIC(4,0,2,0,0),

--- a/src/x11glvnd/x11glvndserver.c
+++ b/src/x11glvnd/x11glvndserver.c
@@ -54,6 +54,8 @@ typedef struct XGLVScreenPrivRec {
 
 DevPrivateKeyRec glvXGLVScreenPrivKey;
 
+#define XGLV_ABI_HAS_LOAD_EXTENSION_LIST \
+    (GET_ABI_MAJOR(ABI_VIDEODRV_VERSION) >= 17)
 #define XGLV_SET_SCREEN_PRIVATE(pScreen, priv) \
     dixSetPrivate(&(pScreen)->devPrivates, &glvXGLVScreenPrivKey, priv)
 #define XGLV_SCREEN_PRIVATE(pScreen) \
@@ -128,7 +130,11 @@ static void *glvSetup(void *module, void *opts, int *errmaj, int *errmin)
         return NULL;
     }
 
+#if XGLV_ABI_HAS_LOAD_EXTENSION_LIST
+    LoadExtensionList(&glvExtensionModule, 1, False);
+#else
     LoadExtension(&glvExtensionModule, False);
+#endif
 
     return (pointer)1;
 }


### PR DESCRIPTION
Hello,

This is an attempt to play with libglvnd on fedora 20/21 with RPM Fusion packaged drivers.
Currently I cannot replace mesa-libGL on optimus device, probably because fedora mesa is built with tls support enabled
This may explain issue like this:
(EE) AIGLX error: dlopen of /usr/lib64/dri/i965_dri.so failed (/usr/lib64/dri/i965_dri.so: undefined symbol: glapi_tls
(EE) AIGLX: reverting to software rendering
(EE) GLX: could not load software renderer
(II) GLX: no usable GL providers found for screen 0

v2: Test features with ABI_VIDEODRV_VERSION
 only use XVENDORNAME if defined.