### PR TITLE
[tests] Fix testpatchentrypoints

### DIFF
--- a/tests/GLX_dummy/GLX_dummy.c
+++ b/tests/GLX_dummy/GLX_dummy.c
@@ -598,11 +598,16 @@ static void dummyFinalizePatch(void)
     }
 }
 
+static void dummyReleasePatch(void)
+{
+}
+
 static const __GLdispatchPatchCallbacks dummyPatchCallbacks =
 {
     .initiatePatch = dummyInitiatePatch,
     .getOffsetHook = dummyGetOffsetHook,
-    .finalizePatch = dummyFinalizePatch
+    .finalizePatch = dummyFinalizePatch,
+    .releasePatch = dummyReleasePatch,
 };
 #endif // defined(PATCH_ENTRYPOINTS)
 


### PR DESCRIPTION
This had been broken since:

    commit 4f1a13cbdac9b20e91558ccb8d06fbff6bfea4fc
    Author: Brian Nguyen <brnguyen@nvidia.com>
    Date:   Wed Nov 12 12:53:07 2014 -0800

	[GLdispatchABI.h] Add a new releasePatch() entrypoint patching callback

which widened __GLdispatchPatchCallbacks but didn't update the test to
match.  We're not any grubbing in the PLT in the dummy library so I
don't think the releasePatch hook needs to do anything.

Fixes 'make check'.

Signed-off-by: Adam Jackson <ajax@redhat.com>