### PR TITLE
[libglvnd] Add NVIDIA license to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,37 @@ Acknowledgements
 Thanks to Andy Ritger for the original libGLX implementation and README
 documentation.
 
+### libglvnd ###
+
+libglvnd itself (excluding components listed below) is licensed as follows:
+
+    Copyright (c) 2013, NVIDIA CORPORATION.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and/or associated documentation files (the
+    "Materials"), to deal in the Materials without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Materials, and to
+    permit persons to whom the Materials are furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    unaltered in all copies or substantial portions of the Materials.
+    Any additions, deletions, or changes to the original source files
+    must be clearly indicated in accompanying documentation.
+
+    If only executable code is distributed, then the accompanying
+    documentation must state that "this software is based in part on the
+    work of the Khronos Group."
+
+    THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
 ### X.Org ###
 
 libglvnd contains list.h, a linked list implementation from the X.Org project.


### PR DESCRIPTION
This is mostly to get the Khronos clause into the documentation, which
distributions will need to include in their binary packages.

Signed-off-by: Adam Jackson <ajax@redhat.com>