### PR TITLE
Threading-related fixes for GLdispatch

### DIFF
--- a/src/GLX/libglx.c
+++ b/src/GLX/libglx.c
@@ -1535,6 +1535,8 @@ void __glXThreadInitialize(void)
             sched_yield();
         }
     }
+
+    __glDispatchCheckMultithreaded();
 }
 
 void CurrentContextHashCleanup(void *unused, __GLXcurrentContextHash *pEntry)

--- a/src/GLdispatch/GLdispatch.c
+++ b/src/GLdispatch/GLdispatch.c
@@ -789,4 +789,11 @@ void __glDispatchFini(void)
     _glapi_destroy_multithread();
 }
 
+void __glDispatchCheckMultithreaded(void)
+{
+    if (!pthreadFuncs.is_singlethreaded)
+    {
+        _glapi_check_multithread();
+    }
+}
 

--- a/src/GLdispatch/GLdispatch.c
+++ b/src/GLdispatch/GLdispatch.c
@@ -54,7 +54,7 @@ static int clientRefcount;
 /*
  * Threading imports used for locking.
  */
-static GLVNDPthreadFuncs pthreadFuncs;
+GLVNDPthreadFuncs pthreadFuncs;
 
 /*
  * The number of current contexts that GLdispatch is aware of

--- a/src/GLdispatch/GLdispatch.h
+++ b/src/GLdispatch/GLdispatch.h
@@ -243,4 +243,10 @@ PUBLIC void __glDispatchUnregisterStubCallbacks(
     void (*restore_func)(void)
 );
 
+/**
+ * Checks to see if multiple threads are being used. This should be called
+ * periodically from places like glXMakeCurrent.
+ */
+PUBLIC void __glDispatchCheckMultithreaded(void);
+
 #endif

--- a/src/GLdispatch/vnd-glapi/mapi/glapi/glapi.h
+++ b/src/GLdispatch/vnd-glapi/mapi/glapi/glapi.h
@@ -183,10 +183,6 @@ _glapi_init_table_from_callback(struct _glapi_table *table,
                                                        int isClientAPI));
 
 
-_GLAPI_EXPORT unsigned long
-_glthread_GetID(void);
-
-
 /*
  * These stubs are kept so that the old DRI drivers still load.
  */

--- a/src/GLdispatch/vnd-glapi/mapi/mapi_glapi.c
+++ b/src/GLdispatch/vnd-glapi/mapi/mapi_glapi.c
@@ -228,12 +228,6 @@ _glapi_get_proc_name(unsigned int offset)
    return stub ? stub_get_name(stub) : NULL;
 }
 
-unsigned long
-_glthread_GetID(void)
-{
-   return u_thread_self();
-}
-
 void
 _glapi_noop_enable_warnings(unsigned char enable)
 {

--- a/src/GLdispatch/vnd-glapi/mapi/stub.c
+++ b/src/GLdispatch/vnd-glapi/mapi/stub.c
@@ -79,8 +79,8 @@ void
 stub_init_once(void)
 {
 #ifdef HAVE_PTHREAD
-   static pthread_once_t once = PTHREAD_ONCE_INIT;
-   pthread_once(&once, entry_init_public);
+   static glvnd_once_t once = GLVND_ONCE_INIT;
+   pthreadFuncs.once(&once, entry_init_public);
 #else
    static int first = 1;
    if (first) {

--- a/src/GLdispatch/vnd-glapi/mapi/u_current.c
+++ b/src/GLdispatch/vnd-glapi/mapi/u_current.c
@@ -151,7 +151,7 @@ u_mutex_declare_static(ThreadCheckMutex);
 void
 u_current_init(void)
 {
-   static unsigned long knownID;
+   static u_thread_t knownID = U_THREAD_INIT;
    static int firstCall = 1;
 
    if (ThreadSafe)
@@ -164,7 +164,7 @@ u_current_init(void)
       knownID = u_thread_self();
       firstCall = 0;
    }
-   else if (knownID != u_thread_self()) {
+   else if (!u_thread_equal(knownID, u_thread_self())) {
       ThreadSafe = 1;
       u_current_set(NULL);
       u_current_set_user(NULL);

--- a/src/GLdispatch/vnd-glapi/mapi/u_current.c
+++ b/src/GLdispatch/vnd-glapi/mapi/u_current.c
@@ -151,8 +151,11 @@ u_mutex_declare_static(ThreadCheckMutex);
 void
 u_current_init(void)
 {
+   // TODO: Move the initialization code (and maybe stub_init_once) to
+   // __glDispatchInit.
    static u_thread_t knownID = U_THREAD_INIT;
    static int firstCall = 1;
+   int i;
 
    if (ThreadSafe)
       return;
@@ -166,8 +169,9 @@ u_current_init(void)
    }
    else if (!u_thread_equal(knownID, u_thread_self())) {
       ThreadSafe = 1;
-      u_current_set(NULL);
-      u_current_set_user(NULL);
+      for (i = 0; i < U_CURRENT_NUM_ENTRIES; i++) {
+         u_current[i] = NULL;
+      }
    }
    u_mutex_unlock(ThreadCheckMutex);
 }
@@ -191,8 +195,6 @@ u_current_init(void)
 void
 u_current_set_user(const void *ptr)
 {
-   u_current_init();
-
 #if defined(GLX_USE_TLS)
    u_current[U_CURRENT_USER0] = (void *) ptr;
 #elif defined(THREADS)
@@ -230,8 +232,6 @@ u_current_get_user_internal(void)
 void
 u_current_set(const struct mapi_table *tbl)
 {
-   u_current_init();
-
    stub_init_once();
 
    if (!tbl)
@@ -289,9 +289,6 @@ u_current_get_index(int index)
 #if defined(GLX_USE_TLS)
             return u_current[index];
 #elif defined(THREADS)
-            if (u_current[index]) {
-                return u_current[index];
-            }
             return (ThreadSafe) ? u_tsd_get(&u_current_tsd[index]) :
                 u_current[index];
 #else

--- a/src/util/glvnd_pthread/glvnd_pthread.h
+++ b/src/util/glvnd_pthread/glvnd_pthread.h
@@ -65,6 +65,8 @@ typedef struct _glvnd_thread_t {
     int singlethreaded;
 } glvnd_thread_t;
 
+#define GLVND_THREAD_NULL_INIT {}
+
 typedef pthread_attr_t glvnd_thread_attr_t;
 typedef pthread_mutexattr_t glvnd_mutexattr_t;
 typedef pthread_rwlockattr_t glvnd_rwlockattr_t;


### PR DESCRIPTION
Various fixes for thread handling in GLdispatch.

The code in mapi/u_current.c should use the glvnd_pthread interface instead of calling into pthreads directly.

Fix a few errors in the x86 TSD version of GLdispatch, where a second thread would try to use the context state from the main thread.