### PR TITLE
Add a QueryVersion request to x11glvnd

### DIFF
--- a/src/x11glvnd/x11glvnd.h
+++ b/src/x11glvnd/x11glvnd.h
@@ -42,6 +42,13 @@
 #define XGLV_EXTENSION_NAME "x11glvnd"
 
 /*!
+ * Returns the version of the x11glvnd extension supported by the server.
+ *
+ * Returns nonzero if the server supports a compatible version of x11glvnd.
+ */
+Status XGLVQueryVersion(Display *dpy, int *major, int *minor);
+
+/*!
  * Returns the screen associated with this XID, or -1 if there was an error.
  */
 int XGLVQueryXIDScreenMapping(

--- a/src/x11glvnd/x11glvnd.h
+++ b/src/x11glvnd/x11glvnd.h
@@ -42,11 +42,22 @@
 #define XGLV_EXTENSION_NAME "x11glvnd"
 
 /*!
+ * Determines if the x11glvnd extension is supported.
+ *
+ * \param[out] event_base_return Returns the base event code.
+ * \param[out] error_base_return Returns the base error code.
+ * \return True if the extension is available, or False if it is not.
+ */
+Bool XGLVQueryExtension(Display *dpy, int *event_base_return, int *error_base_return);
+
+/*!
  * Returns the version of the x11glvnd extension supported by the server.
  *
- * Returns nonzero if the server supports a compatible version of x11glvnd.
+ * \param[out] major Returns the major version number.
+ * \param[out] minor Returns the minor version number.
+ * \return nonzero if the server supports a compatible version of x11glvnd.
  */
-Status XGLVQueryVersion(Display *dpy, int *major, int *minor);
+Bool XGLVQueryVersion(Display *dpy, int *major, int *minor);
 
 /*!
  * Returns the screen associated with this XID, or -1 if there was an error.
@@ -59,6 +70,8 @@ int XGLVQueryXIDScreenMapping(
 /*!
  * Returns the vendor associated with this screen, or NULL if there was an
  * error.
+ *
+ * The caller must free the string with XFree.
  */
 char *XGLVQueryScreenVendorMapping(
     Display *dpy,

--- a/src/x11glvnd/x11glvndclient.c
+++ b/src/x11glvnd/x11glvndclient.c
@@ -129,6 +129,38 @@ static XEXT_CLOSE_DISPLAY_PROTO(close_display)
    } while (0)
 
 
+Status XGLVQueryVersion(Display *dpy, int *major, int *minor)
+{
+    XExtDisplayInfo *info = find_display(dpy);
+    xglvQueryVersionReq *req;
+    xglvQueryVersionReply rep;
+
+    LockDisplay(dpy);
+
+    if (!XextHasExtension(info)) {
+        return 0;
+    }
+
+    GetReq(glvQueryVersion, req);
+
+    req->reqType = info->codes->major_opcode;
+    req->glvndReqType = X_glvQueryVersion;
+    req->majorVersion = XGLV_EXT_MAJOR;
+    req->minorVersion = XGLV_EXT_MINOR;
+
+    if (!_XReply(dpy, (xReply*)&rep, 0, xTrue)) {
+        UnlockDisplay(dpy);
+        SyncHandle();
+        return 0;
+    }
+
+    *major = rep.majorVersion;
+    *minor = rep.minorVersion;
+    UnlockDisplay(dpy);
+    SyncHandle();
+    return 1;
+}
+
 /*
  * Returns the screen associated with this XID, or -1 if there was an error.
  */

--- a/src/x11glvnd/x11glvndclient.c
+++ b/src/x11glvnd/x11glvndclient.c
@@ -135,7 +135,7 @@ Bool XGLVQueryExtension(Display *dpy, int *event_base_return, int *error_base_re
     if (XextHasExtension(info)) {
         *event_base_return = info->codes->first_event;
         *error_base_return = info->codes->first_error;
-        return False;
+        return True;
     } else {
         return False;
     }

--- a/src/x11glvnd/x11glvndclient.c
+++ b/src/x11glvnd/x11glvndclient.c
@@ -129,7 +129,19 @@ static XEXT_CLOSE_DISPLAY_PROTO(close_display)
    } while (0)
 
 
-Status XGLVQueryVersion(Display *dpy, int *major, int *minor)
+Bool XGLVQueryExtension(Display *dpy, int *event_base_return, int *error_base_return)
+{
+    XExtDisplayInfo *info = find_display(dpy);
+    if (XextHasExtension(info)) {
+        *event_base_return = info->codes->first_event;
+        *error_base_return = info->codes->first_error;
+        return False;
+    } else {
+        return False;
+    }
+}
+
+Bool XGLVQueryVersion(Display *dpy, int *major, int *minor)
 {
     XExtDisplayInfo *info = find_display(dpy);
     xglvQueryVersionReq *req;
@@ -137,9 +149,7 @@ Status XGLVQueryVersion(Display *dpy, int *major, int *minor)
 
     LockDisplay(dpy);
 
-    if (!XextHasExtension(info)) {
-        return 0;
-    }
+    CHECK_EXTENSION(dpy, info, -1);
 
     GetReq(glvQueryVersion, req);
 

--- a/src/x11glvnd/x11glvndclient.c
+++ b/src/x11glvnd/x11glvndclient.c
@@ -149,7 +149,7 @@ Bool XGLVQueryVersion(Display *dpy, int *major, int *minor)
 
     LockDisplay(dpy);
 
-    CHECK_EXTENSION(dpy, info, -1);
+    CHECK_EXTENSION(dpy, info, False);
 
     GetReq(glvQueryVersion, req);
 
@@ -161,14 +161,14 @@ Bool XGLVQueryVersion(Display *dpy, int *major, int *minor)
     if (!_XReply(dpy, (xReply*)&rep, 0, xTrue)) {
         UnlockDisplay(dpy);
         SyncHandle();
-        return 0;
+        return False;
     }
 
     *major = rep.majorVersion;
     *minor = rep.minorVersion;
     UnlockDisplay(dpy);
     SyncHandle();
-    return 1;
+    return True;
 }
 
 /*

--- a/src/x11glvnd/x11glvndproto.h
+++ b/src/x11glvnd/x11glvndproto.h
@@ -96,11 +96,10 @@ __GLV_DEFINE_REQ(QueryVersion,
 __GLV_DEFINE_REPLY(QueryVersion,
     CARD32 majorVersion B32;
     CARD32 minorVersion B32;
-    CARD32 padl4;
-    CARD32 padl5;
-    CARD32 padl6;
-    CARD32 padl7;
-    CARD32 padl8;
+    CARD32 padl4 B32;
+    CARD32 padl5 B32;
+    CARD32 padl6 B32;
+    CARD32 padl7 B32;
 );
 
 __GLV_DEFINE_REQ(QueryXIDScreenMapping,
@@ -109,12 +108,11 @@ __GLV_DEFINE_REQ(QueryXIDScreenMapping,
 
 __GLV_DEFINE_REPLY(QueryXIDScreenMapping,
     INT32  screen B32;
-    CARD32 padl3;
-    CARD32 padl4;
-    CARD32 padl5;
-    CARD32 padl6;
-    CARD32 padl7;
-    CARD32 padl8;
+    CARD32 padl3 B32;
+    CARD32 padl4 B32;
+    CARD32 padl5 B32;
+    CARD32 padl6 B32;
+    CARD32 padl7 B32;
 );
 
 __GLV_DEFINE_REQ(QueryScreenVendorMapping,
@@ -123,12 +121,11 @@ __GLV_DEFINE_REQ(QueryScreenVendorMapping,
 
 __GLV_DEFINE_REPLY(QueryScreenVendorMapping,
     CARD32 n    B32;
-    CARD32 padl3;
-    CARD32 padl4;
-    CARD32 padl5;
-    CARD32 padl6;
-    CARD32 padl7;
-    CARD32 padl8;
+    CARD32 padl3 B32;
+    CARD32 padl4 B32;
+    CARD32 padl5 B32;
+    CARD32 padl6 B32;
+    CARD32 padl7 B32;
 );
 
 #undef __GLV_DEFINE_REQ

--- a/src/x11glvnd/x11glvndproto.h
+++ b/src/x11glvnd/x11glvndproto.h
@@ -39,12 +39,13 @@
 #define XGLV_NUM_EVENTS 0
 #define XGLV_NUM_ERRORS 0
 
-#define XGLV_EXT_MAJOR 0
+#define XGLV_EXT_MAJOR 1
 #define XGLV_EXT_MINOR 0
 
 // TODO: X_glvQueryXIDVendorMapping?
-#define X_glvQueryXIDScreenMapping      0
-#define X_glvQueryScreenVendorMapping   1
+#define X_glvQueryVersion               0
+#define X_glvQueryXIDScreenMapping      1
+#define X_glvQueryScreenVendorMapping   2
 #define X_glvLastRequest  (X_glvQueryScreenVendorMapping+1)
 
 #define GLVND_PAD(x) (((x)+3) & ~3)
@@ -86,6 +87,21 @@ static const size_t sz_xglv ## name ## Req =  \
     } xglv ## name ## Reply;                   \
 static const size_t sz_xglv ## name ## Reply = \
     32 // sizeof(xReply)
+
+__GLV_DEFINE_REQ(QueryVersion,
+    CARD32 majorVersion B32;
+    CARD32 minorVersion B32;
+);
+
+__GLV_DEFINE_REPLY(QueryVersion,
+    CARD32 majorVersion B32;
+    CARD32 minorVersion B32;
+    CARD32 padl4;
+    CARD32 padl5;
+    CARD32 padl6;
+    CARD32 padl7;
+    CARD32 padl8;
+);
 
 __GLV_DEFINE_REQ(QueryXIDScreenMapping,
     CARD32 xid B32;

--- a/src/x11glvnd/x11glvndserver.c
+++ b/src/x11glvnd/x11glvndserver.c
@@ -90,9 +90,9 @@ PROC_PROTO(QueryXIDScreenMapping);
 PROC_PROTO(QueryScreenVendorMapping);
 
 static ProcVectorFuncPtr glvProcVector[X_glvLastRequest] = {
+    PROC_VECTOR_ENTRY(QueryVersion),
     PROC_VECTOR_ENTRY(QueryXIDScreenMapping),
     PROC_VECTOR_ENTRY(QueryScreenVendorMapping),
-    PROC_VECTOR_ENTRY(QueryVersion),
 };
 
 #undef PROC_VECTOR_ENTRY


### PR DESCRIPTION
This adds a new request to the x11glvnd extension to check the version of the extension that the server supports.

The request is at index 0, bumping the two existing requests by one.