### PR TITLE
libGLX: Rework the ABI for object-to-vendor mappings.

### DIFF
--- a/src/GLX/libglxabi.h
+++ b/src/GLX/libglxabi.h
@@ -121,10 +121,20 @@ typedef struct __GLXapiExportsRec {
      * and add mappings between various objects and screens.
      ************************************************************************/
 
+    /*!
+     * Records the screen number and vendor for a context. The screen and
+     * vendor must be the ones returned for the XVisualInfo or GLXFBConfig that
+     * the context is created from.
+     */
     void (*addScreenContextMapping)(Display *dpy, GLXContext context, int screen, __GLXvendorInfo *vendor);
+
+    /*!
+     * Removes a mapping from context to vendor. The context must have been
+     * added with \p addScreenContextMapping.
+     */
     void (*removeScreenContextMapping)(Display *dpy, GLXContext context);
 
-    /**
+    /*!
      * Looks up the screen and vendor for a context.
      *
      * If no mapping is found, then \p retScreen and \p retVendor will be set
@@ -145,10 +155,14 @@ typedef struct __GLXapiExportsRec {
     void (*removeScreenFBConfigMapping)(Display *dpy, GLXFBConfig config);
     int (*vendorFromFBConfig)(Display *dpy, GLXFBConfig config, int *retScreen, __GLXvendorInfo **retVendor);
 
+    void (*addScreenVisualMapping)(Display *dpy, const XVisualInfo *visual, __GLXvendorInfo *vendor);
+    void (*removeScreenVisualMapping)(Display *dpy, const XVisualInfo *visual);
+    int (*vendorFromVisual)(Display *dpy, const XVisualInfo *visual, __GLXvendorInfo **retVendor);
+
     void (*addScreenDrawableMapping)(Display *dpy, GLXDrawable drawable, int screen, __GLXvendorInfo *vendor);
     void (*removeScreenDrawableMapping)(Display *dpy, GLXDrawable drawable);
 
-    /**
+    /*!
      * Looks up the screen and vendor for a drawable.
      *
      * If the server does not support the x11glvnd extension, then this

--- a/src/GLX/libglxabi.h
+++ b/src/GLX/libglxabi.h
@@ -68,7 +68,7 @@ extern "C" {
  * It is allocated at runtime by the API library. Vendor-provided dispatch
  * functions retrieve and operate on this structure using the API below.
  */
-typedef struct __GLXdispatchTableDynamicRec __GLXdispatchTableDynamic;
+typedef struct __GLXvendorInfoRec __GLXvendorInfo;
 
 /*!
  * Forward declaration for createGLDispatch export.
@@ -89,21 +89,21 @@ typedef struct __GLXapiExportsRec {
      * This fetches the appropriate dynamic GLX dispatch table given the display
      * and screen number.
      */
-    __GLXdispatchTableDynamic *(*getDynDispatch)(Display *dpy,
+    __GLXvendorInfo *(*getDynDispatch)(Display *dpy,
                                                  const int screen);
 
     /*!
      * This function retrieves the appropriate current dynamic dispatch table,
      * if a GL context is current. Otherwise, this returns NULL.
      */
-    __GLXdispatchTableDynamic *(*getCurrentDynDispatch)(void);
+    __GLXvendorInfo *(*getCurrentDynDispatch)(void);
 
     /*!
      * This function retrieves an entry point from the dynamic dispatch table
      * given an index into the table.
      */
     __GLXextFuncPtr           (*fetchDispatchEntry)
-        (__GLXdispatchTableDynamic *dynDispatch, int index);
+        (__GLXvendorInfo *dynDispatch, int index);
 
     /************************************************************************
      * This routine is used by the vendor to lookup its context structure.
@@ -121,17 +121,44 @@ typedef struct __GLXapiExportsRec {
      * and add mappings between various objects and screens.
      ************************************************************************/
 
-    void (*addScreenContextMapping)(GLXContext context, int screen);
-    void (*removeScreenContextMapping)(GLXContext context);
-    int  (*screenFromContext)(GLXContext context);
+    void (*addScreenContextMapping)(Display *dpy, GLXContext context, int screen, __GLXvendorInfo *vendor);
+    void (*removeScreenContextMapping)(Display *dpy, GLXContext context);
 
-    void (*addScreenFBConfigMapping)(GLXFBConfig config, int screen);
-    void (*removeScreenFBConfigMapping)(GLXFBConfig config);
-    int  (*screenFromFBConfig)(GLXFBConfig config);
+    /**
+     * Looks up the screen and vendor for a context.
+     *
+     * If no mapping is found, then \p retScreen and \p retVendor will be set
+     * to -1 and NULL, respectively.
+     *
+     * Either of \p retScreen or \p retVendor may be NULL if the screen or
+     * vendor are not required.
+     *
+     * \param dpy The display connection.
+     * \param context The context to look up.
+     * \param[out] retScreen Returns the screen number.
+     * \param[out] retVendor Returns the vendor.
+     * \return Zero if a match was found, or non-zero if it was not.
+     */
+    int (*vendorFromContext)(Display *dpy, GLXContext context, int *retScreen, __GLXvendorInfo **retVendor);
 
-    void (*addScreenDrawableMapping)(GLXDrawable drawable, int screen);
-    void (*removeScreenDrawableMapping)(GLXDrawable drawable);
-    int  (*screenFromDrawable)(Display *dpy, GLXDrawable drawable);
+    void (*addScreenFBConfigMapping)(Display *dpy, GLXFBConfig config, int screen, __GLXvendorInfo *vendor);
+    void (*removeScreenFBConfigMapping)(Display *dpy, GLXFBConfig config);
+    int (*vendorFromFBConfig)(Display *dpy, GLXFBConfig config, int *retScreen, __GLXvendorInfo **retVendor);
+
+    void (*addScreenDrawableMapping)(Display *dpy, GLXDrawable drawable, int screen, __GLXvendorInfo *vendor);
+    void (*removeScreenDrawableMapping)(Display *dpy, GLXDrawable drawable);
+
+    /**
+     * Looks up the screen and vendor for a drawable.
+     *
+     * If the server does not support the x11glvnd extension, then this
+     * function may not be able to determine the screen number for a drawable.
+     * In that case, it will return -1 for the screen number.
+     *
+     * Even without x11glvnd, this function will still return a vendor
+     * suitable for indirect rendering.
+     */
+    int (*vendorFromDrawable)(Display *dpy, GLXDrawable drawable, int *retScreen, __GLXvendorInfo **retVendor);
 
 } __GLXapiExports;
 

--- a/src/GLX/libglxcurrent.h
+++ b/src/GLX/libglxcurrent.h
@@ -101,7 +101,7 @@ static inline const __GLXdispatchTableStatic *__glXGetCurrentDispatch(void)
  * This gets the current GLX dynamic dispatch table, which is stored in the API
  * state.
  */
-__GLXdispatchTableDynamic *__glXGetCurrentDynDispatch(void);
+__GLXvendorInfo *__glXGetCurrentDynDispatch(void);
 
 /*!
  * This gets the current (vendor-specific) context, which is stored directly

--- a/src/GLX/libglxmapping.c
+++ b/src/GLX/libglxmapping.c
@@ -291,6 +291,10 @@ static void InitExportsTable(void)
     glxExportsTable.removeScreenFBConfigMapping = __glXRemoveScreenFBConfigMapping;
     glxExportsTable.vendorFromFBConfig = __glXVendorFromFBConfig;
 
+    glxExportsTable.addScreenVisualMapping = __glXAddScreenVisualMapping;
+    glxExportsTable.removeScreenVisualMapping = __glXRemoveScreenVisualMapping;
+    glxExportsTable.vendorFromVisual = __glXVendorFromVisual;
+
     glxExportsTable.addScreenDrawableMapping = __glXAddScreenDrawableMapping;
     glxExportsTable.removeScreenDrawableMapping = __glXRemoveScreenDrawableMapping;
     glxExportsTable.vendorFromDrawable = __glXVendorFromDrawable;
@@ -783,6 +787,21 @@ int __glXVendorFromFBConfig(Display *dpy, GLXFBConfig config, int *retScreen, __
     return CommonVendorFromScreen(dpy, screen, retScreen, retVendor);
 }
 
+// Internally, we use the screen number to look up a vendor, so we don't need
+// to record anything else for an XVisualInfo.
+void __glXAddScreenVisualMapping(Display *dpy, const XVisualInfo *visual, __GLXvendorInfo *vendor)
+{
+}
+void __glXRemoveScreenVisualMapping(Display *dpy, const XVisualInfo *visual)
+{
+}
+int __glXVendorFromVisual(Display *dpy, const XVisualInfo *visual, __GLXvendorInfo **retVendor)
+{
+    if (retVendor != NULL) {
+        *retVendor = __glXLookupVendorByScreen(dpy, visual->screen);
+    }
+    return 0;
+}
 
 
 

--- a/src/GLX/libglxmapping.h
+++ b/src/GLX/libglxmapping.h
@@ -87,6 +87,10 @@ void __glXRemoveScreenFBConfigMapping(Display *dpy, GLXFBConfig config);
 int __glXScreenFromFBConfig(GLXFBConfig config);
 int __glXVendorFromFBConfig(Display *dpy, GLXFBConfig config, int *retScreen, __GLXvendorInfo **retVendor);
 
+void __glXAddScreenVisualMapping(Display *dpy, const XVisualInfo *visual, __GLXvendorInfo *vendor);
+void __glXRemoveScreenVisualMapping(Display *dpy, const XVisualInfo *visual);
+int __glXVendorFromVisual(Display *dpy, const XVisualInfo *visual, __GLXvendorInfo **retVendor);
+
 void __glXAddScreenDrawableMapping(Display *dpy, GLXDrawable drawable, int screen, __GLXvendorInfo *vendor);
 void __glXRemoveScreenDrawableMapping(Display *dpy, GLXDrawable drawable);
 int __glXScreenFromDrawable(Display *dpy, GLXDrawable drawable);

--- a/src/GLX/libglxmapping.h
+++ b/src/GLX/libglxmapping.h
@@ -35,6 +35,8 @@
 
 #define GLX_CLIENT_STRING_LAST_ATTRIB GLX_EXTENSIONS
 
+typedef struct __GLXdispatchTableDynamicRec __GLXdispatchTableDynamic;
+
 /*!
  * Structure containing relevant per-vendor information.
  */
@@ -61,25 +63,34 @@ typedef struct __GLXdisplayInfoRec {
  */
 const __GLXdispatchTableStatic * __glXGetStaticDispatch(Display *dpy,
                                                         const int screen);
-__GLXdispatchTableDynamic *__glXGetDynDispatch(Display *dpy,
+__GLXvendorInfo *__glXGetDynDispatch(Display *dpy,
                                                const int screen);
 __GLdispatchTable *__glXGetGLDispatch(Display *dpy, const int screen);
+
+__GLXvendorInfo *__glXGetDrawableDynDispatch(Display *dpy,
+                                               GLXDrawable drawable);
+
+const __GLXdispatchTableStatic * __glXGetDrawableStaticDispatch(Display *dpy,
+                                                        GLXDrawable drawable);
 
 /*!
  * Various functions to manage mappings used to determine the screen
  * of a particular GLX call.
  */
-void __glXAddScreenContextMapping(GLXContext context, int screen);
-void __glXRemoveScreenContextMapping(GLXContext context);
+void __glXAddScreenContextMapping(Display *dpy, GLXContext context, int screen, __GLXvendorInfo *vendor);
+void __glXRemoveScreenContextMapping(Display *dpy, GLXContext context);
 int __glXScreenFromContext(GLXContext context);
+int __glXVendorFromContext(Display *dpy, GLXContext context, int *retScreen, __GLXvendorInfo **retVendor);
 
-void __glXAddScreenFBConfigMapping(GLXFBConfig config, int screen);
-void __glXRemoveScreenFBConfigMapping(GLXFBConfig config);
+void __glXAddScreenFBConfigMapping(Display *dpy, GLXFBConfig config, int screen, __GLXvendorInfo *vendor);
+void __glXRemoveScreenFBConfigMapping(Display *dpy, GLXFBConfig config);
 int __glXScreenFromFBConfig(GLXFBConfig config);
+int __glXVendorFromFBConfig(Display *dpy, GLXFBConfig config, int *retScreen, __GLXvendorInfo **retVendor);
 
-void __glXAddScreenDrawableMapping(GLXDrawable drawable, int screen);
-void __glXRemoveScreenDrawableMapping(GLXDrawable drawable);
+void __glXAddScreenDrawableMapping(Display *dpy, GLXDrawable drawable, int screen, __GLXvendorInfo *vendor);
+void __glXRemoveScreenDrawableMapping(Display *dpy, GLXDrawable drawable);
 int __glXScreenFromDrawable(Display *dpy, GLXDrawable drawable);
+int __glXVendorFromDrawable(Display *dpy, GLXDrawable drawable, int *retScreen, __GLXvendorInfo **retVendor);
 
 __GLXextFuncPtr __glXGetGLXDispatchAddress(const GLubyte *procName);
 

--- a/tests/GLX_dummy/GLX_dummy.c
+++ b/tests/GLX_dummy/GLX_dummy.c
@@ -398,7 +398,7 @@ static void dispatch_glXExampleExtensionFunction(Display *dpy,
                                                 int screen,
                                                 int *retval)
 {
-    __GLXdispatchTableDynamic *dynDispatch;
+    __GLXvendorInfo *dynDispatch;
     ExampleExtensionFunctionPtr func;
     const int index = dummyExampleExtensionFunctionIndex;
 


### PR DESCRIPTION
The current interface between libGLX and libGLX_vendor maps from objects (drawables, contexts, FBconfigs) to screens, and then from screens to vendors. As a result, the interface requires that every screen have exactly one vendor, which all objects on that screen have to use.

We could instead change the interface so that it maps from objects to (screen, vendor) pairs. When you create a context or drawable from a GLXFBConfig, it would inherit the config's vendor.

How each config maps to a vendor would be an implementation detail within libGLX. While it might use an (object -> screen -> vendor) mapping now, future versions of libglvnd could allow for other options without having to change any vendor libraries.