### PR TITLE
Patch entrypoint rework

### DIFF
--- a/src/GL/libgl.c
+++ b/src/GL/libgl.c
@@ -36,6 +36,8 @@
 #include "stub.h"
 #include "GLdispatch.h"
 
+static int patchStubId = -1;
+
 // Initialize GLX imports
 #if defined(USE_ATTRIBUTE_CONSTRUCTOR)
 void __attribute__((constructor)) __libGLInit(void)
@@ -50,7 +52,7 @@ void _init(void)
 
     // Register these entrypoints with GLdispatch so they can be overwritten at
     // runtime
-    __glDispatchRegisterStubCallbacks(stub_get_offsets, stub_restore);
+    patchStubId = __glDispatchRegisterStubCallbacks(stub_get_patch_callbacks());
 
     // Lookup function pointers from libGLX for the GLX entrypoints
     __glXWrapperInit(__glXGetCachedProcAddress);
@@ -63,5 +65,5 @@ void _fini(void)
 #endif
 {
     // Unregister the GLdispatch entrypoints
-    __glDispatchUnregisterStubCallbacks(stub_get_offsets, stub_restore);
+    __glDispatchUnregisterStubCallbacks(patchStubId);
 }

--- a/src/GLdispatch/GLdispatch.h
+++ b/src/GLdispatch/GLdispatch.h
@@ -203,24 +203,6 @@ PUBLIC GLint __glDispatchGetOffset(const GLubyte *procName);
 PUBLIC void __glDispatchSetEntry(__GLdispatchTable *dispatch,
                                  GLint offset, __GLdispatchProc addr);
 
-/*!
- * This registers stubs with GLdispatch to be overwritten if a vendor library
- * explicitly requests custom entrypoint code.  This is used by the wrapper
- * interface libraries.
- */
-PUBLIC void __glDispatchRegisterStubCallbacks(
-    void (*get_offsets_func)(__GLdispatchGetOffsetHook func),
-    void (*restore_func)(void)
-);
-
-/*!
- * This unregisters the GLdispatch stubs, and performs any necessary cleanup.
- */
-PUBLIC void __glDispatchUnregisterStubCallbacks(
-    void (*get_offsets_func)(__GLdispatchGetOffsetHook func),
-    void (*restore_func)(void)
-);
-
 /**
  * Checks to see if multiple threads are being used. This should be called
  * periodically from places like glXMakeCurrent.

--- a/src/GLdispatch/GLdispatchABI.h
+++ b/src/GLdispatch/GLdispatchABI.h
@@ -67,38 +67,79 @@ enum {
     __GLDISPATCH_STUB_NUM_TYPES
 };
 
+/*!
+ * A callback function called by the vendor library to fetch the address of an
+ * entrypoint.
+ *
+ * The function returns two pointers, one writable and one executable. The two
+ * pointers may or may not be the same virtual address, but they will both be
+ * mappings of the same physical memory.
+ *
+ * The vendor library should write its entrypoint to the address returned by
+ * \p writePtr, but should use the address from \p execPtr for things like
+ * calculating PC-relative offsets.
+ *
+ * Note that if this function fails, then the vendor library can still try to
+ * patch other entrypoints.
+ *
+ * \param funcName The function name.
+ * \param[out] writePtr The pointer that the vendor library can write to.
+ * \param[out] execPtr The pointer to the executable code.
+ * \return GL_TRUE if the entrypoint exists, or GL_FALSE if it doesn't.
+ */
+typedef GLboolean (*DispatchPatchLookupStubOffset)(const char *funcName,
+        void **writePtr, const void **execPtr);
+
 typedef struct __GLdispatchPatchCallbacksRec {
-    /*
+    /*!
+     * Checks to see if the vendor library supports patching the given stub
+     * type and size.
+     *
+     * \param type The type of entrypoints. This will be a one of the
+     * __GLDISPATCH_STUB_* values.
+     * \param stubSize The maximum size of the stub that the vendor library can
+     * write, in bytes.
+     * \param lookupStubOffset A callback into libglvnd to look up the address
+     * of each entrypoint.
+     */
+    GLboolean (* checkPatchSupported)(int type, int stubSize);
+
+    /*!
      * Called by libglvnd to request that a vendor library patch its top-level
-     * entrypoints.  The vendor should return GL_TRUE if patching is supported
-     * with this type and stub size, or GL_FALSE otherwise.  If this is the first
-     * time libglvnd calls into the vendor with the given stubGeneration argument,
-     * the vendor is expected to set the boolean pointed to by needOffsets to
-     * GL_TRUE; otherwise, it should be set to GL_FALSE.
+     * entrypoints.
+     *
+     * The vendor library should use the \p lookupStubOffset callback to find
+     * the addresses of each entrypoint.
+     *
+     * This function may be called more than once to patch multiple sets of
+     * entrypoints. For example, depending on how they're built, libOpenGL.so
+     * or libGL.so may have their own entrypoints that are separate functions
+     * from the ones in libGLdispatch.
+     *
+     * Note that during this call is the only time that the entrypoints can be
+     * modified. After the call to \c initiatePatch returns, the vendor library
+     * should treat the entrypoints as read-only.
+     *
+     * \param type The type of entrypoints. This will be a one of the
+     * __GLDISPATCH_STUB_* values.
+     * \param stubSize The maximum size of the stub that the vendor library can
+     * write, in bytes.
+     * \param lookupStubOffset A callback into libglvnd to look up the address
+     * of each entrypoint.
+     *
+     * \return GL_TRUE if the vendor library supports patching with this type
+     * and size.
      */
     GLboolean (*initiatePatch)(int type,
                                int stubSize,
-                               GLint64 stubGeneration,
-                               GLboolean *needOffsets);
+                               DispatchPatchLookupStubOffset lookupStubOffset);
 
-    /*
-     * Hook by which the vendor library may request stub offsets if it set
-     * *needOffsets == GL_TRUE above.
-     */
-    void (*getOffsetHook)(void *(*lookupStubOffset)(const char *funcName));
-
-    /*
-     * Called by libglvnd to finish the initial top-level entrypoint patch.
-     * libglvnd must have called the __GLdispatchInitiatePatch callback first!
-     * After this function is called, the vendor "owns" the top-level
-     * entrypoints and may change them at will until GLdispatch calls the
-     * releasePatch callback below.
-     */
-    void (*finalizePatch)(void);
-
-    /*
+    /*!
      * Called by libglvnd to notify the current vendor that it no longer owns
      * the top-level entrypoints.
+     *
+     * Libglvnd will take care of the restoring the entrypoints back to their
+     * original state. The vendor library must not try to modify them.
      */
     void (*releasePatch)(void);
 } __GLdispatchPatchCallbacks;

--- a/src/GLdispatch/vnd-glapi/mapi/glapi/glapi.h
+++ b/src/GLdispatch/vnd-glapi/mapi/glapi/glapi.h
@@ -45,6 +45,7 @@
 #define _GLAPI_H
 
 #include <stddef.h>
+#include <GL/gl.h>
 #include "u_compiler.h"
 
 #ifdef __cplusplus
@@ -190,6 +191,34 @@ _glapi_set_warning_func(_glapi_proc func);
  */
 typedef struct __GLdispatchStubPatchCallbacksRec {
     /**
+     * Called before trying to patch any entrypoints.
+     *
+     * If startPatch succeeds, then libGLdispatch will call \c getPatchOffsets
+     * to fetch the address of each function.
+     *
+     * After it finishes patching, libGLdispatch will call either
+     * \c finishPatch or \c abortPatch.
+     *
+     * \return GL_TRUE on success, GL_FALSE on failure.
+     */
+    GLboolean (* startPatch) (void);
+
+    /**
+     * Finishes any patching. This is called after \c startPatch if patching
+     * is successful.
+     */
+    void (* finishPatch) (void);
+
+    /**
+     * Finishes any patching, and restores the entrypoints to their original
+     * state.
+     *
+     * This is called if an error occurrs and libGLdispatch has to abort
+     * patching the entrypoints.
+     */
+    void (* abortPatch) (void);
+
+    /**
      * Called by libGLdispatch to restore each entrypoint to its normal,
      * unpatched behavior.
      */
@@ -198,8 +227,10 @@ typedef struct __GLdispatchStubPatchCallbacksRec {
     /**
      * Returns the address of a function to patch. This may or may not create a
      * new stub function if one doesn't already exist.
+     *
+     * This function is passed to __GLdispatchPatchCallbacks::initiatePatch.
      */
-    void * (* getPatchOffset) (const char *name);
+    GLboolean (* getPatchOffset) (const char *name, void **writePtr, const void **execPtr);
 
     /**
      * Returns the type of the stub functions. This is one of the

--- a/src/GLdispatch/vnd-glapi/mapi/glapi/glapi.h
+++ b/src/GLdispatch/vnd-glapi/mapi/glapi/glapi.h
@@ -179,6 +179,63 @@ _glapi_noop_enable_warnings(unsigned char enable);
 _GLAPI_EXPORT void
 _glapi_set_warning_func(_glapi_proc func);
 
+/**
+ * Functions used for patching entrypoints. These functions are exported from
+ * an entrypoint library such as libGL.so or libOpenGL.so, and used in
+ * libGLdispatch.
+ *
+ * \note The \c startPatch, \c finishPatch, and \c abortPatch functions are
+ * currently unused, but will be used after some changes to
+ * __GLdispatchPatchCallbacks are finished.
+ */
+typedef struct __GLdispatchStubPatchCallbacksRec {
+    /**
+     * Called by libGLdispatch to restore each entrypoint to its normal,
+     * unpatched behavior.
+     */
+    void (* restoreFuncs) (void);
+
+    /**
+     * Returns the address of a function to patch. This may or may not create a
+     * new stub function if one doesn't already exist.
+     */
+    void * (* getPatchOffset) (const char *name);
+
+    /**
+     * Returns the type of the stub functions. This is one of the
+     * __GLDISPATCH_STUB_* values.
+     */
+    int (* getStubType) (void);
+
+    /**
+     * Returns the size of each stub.
+     */
+    int (* getStubSize) (void);
+
+} __GLdispatchStubPatchCallbacks;
+
+/*!
+ * This registers stubs with GLdispatch to be overwritten if a vendor library
+ * explicitly requests custom entrypoint code.  This is used by the wrapper
+ * interface libraries.
+ *
+ * This function returns an ID number, which is passed to
+ * \c __glDispatchUnregisterStubCallbacks to unregister the callbacks.
+ *
+ * \see stub_get_patch_callbacks for the table used for the entrypoints in
+ * libGL, libOpenGL, and libGLdispatch.
+ *
+ * \param callbacks A table of callback functions.
+ * \return A unique ID number, or -1 on failure.
+ */
+_GLAPI_EXPORT int __glDispatchRegisterStubCallbacks(const __GLdispatchStubPatchCallbacks *callbacks);
+
+/*!
+ * This unregisters the GLdispatch stubs, and performs any necessary cleanup.
+ *
+ * \param stubId The ID number returned from \c __glDispatchRegisterStubCallbacks.
+ */
+_GLAPI_EXPORT void __glDispatchUnregisterStubCallbacks(int stubId);
 
 #ifdef __cplusplus
 }

--- a/src/GLdispatch/vnd-glapi/mapi/stub.h
+++ b/src/GLdispatch/vnd-glapi/mapi/stub.h
@@ -29,6 +29,7 @@
 #define _STUB_H_
 
 #include "entry.h"
+#include "glapi/glapi.h"
 
 struct mapi_stub;
 
@@ -56,17 +57,10 @@ mapi_func
 stub_get_addr(const struct mapi_stub *stub);
 #endif // !defined(STATIC_DISPATCH_ONLY)
 
-typedef void (*stub_get_offset_hook)(void *(*)(const char *));
-
-int
-stub_allow_override(void);
-
-void
-stub_get_offsets(
-    stub_get_offset_hook get_offset_hook
-);
-
-void
-stub_restore(void);
+/**
+ * Returns the \c __GLdispatchStubPatchCallbacks struct that should be used for
+ * patching the entrypoints, or \c NULL if patching is not supported.
+ */
+const __GLdispatchStubPatchCallbacks *stub_get_patch_callbacks(void);
 
 #endif /* _STUB_H_ */

--- a/src/OpenGL/libopengl.c
+++ b/src/OpenGL/libopengl.c
@@ -35,6 +35,8 @@
 #include "stub.h"
 #include "GLdispatch.h"
 
+static int patchStubId = -1;
+
 // Initialize OpenGL imports
 #if defined(USE_ATTRIBUTE_CONSTRUCTOR)
 void __attribute__((constructor)) __libGLInit(void)
@@ -49,7 +51,7 @@ void _init(void)
 
     // Register these entrypoints with GLdispatch so they can be
     // overwritten at runtime
-    __glDispatchRegisterStubCallbacks(stub_get_offsets, stub_restore);
+    patchStubId = __glDispatchRegisterStubCallbacks(stub_get_patch_callbacks());
 }
 
 #if defined(USE_ATTRIBUTE_CONSTRUCTOR)
@@ -59,5 +61,5 @@ void _fini(void)
 #endif
 {
     // Unregister the GLdispatch entrypoints
-    __glDispatchUnregisterStubCallbacks(stub_get_offsets, stub_restore);
+    __glDispatchUnregisterStubCallbacks(patchStubId);
 }


### PR DESCRIPTION
These changes rewrite the interface that lets a vendor library patch the OpenGL entrypoints in libGLdispatch.

My goal is partly to simplify the interface and hopefully make it easier to keep the ABI stable, and partly in preparation for fixing the other patching-related bugs (#36 and #37).

From a simplicity standpoint, the new interface lets a vendor library look up an entrypoint, patch it, and then forget about it, whereas the current interface requires it to collect multiple copies of every entrypoint into some internal structure and then patch them all later.

For dealing with the patching bugs, the changes let it use different addresses for a writable and executable mapping, neither of which has to be the same address as the entrypoint passed to the application.
