### PR TITLE
libGLX: Add a function to check if a vendor library supports a screen.

### DIFF
--- a/src/GLX/libglxabi.h
+++ b/src/GLX/libglxabi.h
@@ -315,6 +315,17 @@ typedef struct __GLX14EntryPointsRec {
  */
 struct __GLXvendorCallbacksRec {
     /*!
+     * Checks if the vendor library can support a given X screen. If this
+     * returns false, then libGLX will fall back to the indirect rendering
+     * library (if one exists).
+     *
+     * \param dpy The display connection.
+     * \param screen The screen number.
+     * \return True if the vendor library can support this screen.
+     */
+    Bool (* checkSupportsScreen) (Display *dpy, int screen);
+
+    /*!
      * This retrieves the pointer to the real GLX or core GL function.
      *
      * \param procName The name of the function.

--- a/src/GLX/libglxmapping.c
+++ b/src/GLX/libglxmapping.c
@@ -595,6 +595,13 @@ __GLXvendorInfo *__glXLookupVendorByScreen(Display *dpy, const int screen)
                 char *queriedVendorName = XGLVQueryScreenVendorMapping(dpy, screen);
                 vendor = __glXLookupVendorByName(queriedVendorName);
                 Xfree(queriedVendorName);
+
+                // Make sure that the vendor library can support this screen.
+                // If it can't, then we'll fall back to the indirect rendering
+                // library.
+                if (!vendor->staticDispatch->glxvc.checkSupportsScreen(dpy, screen)) {
+                    vendor = NULL;
+                }
             }
         }
 

--- a/tests/GLX_dummy/GLX_dummy.c
+++ b/tests/GLX_dummy/GLX_dummy.c
@@ -439,6 +439,11 @@ static void dummyNopStub (void)
 }
 
 // XXX non-entry point ABI functions
+static Bool          dummyCheckSupportsScreen    (Display *dpy, int screen)
+{
+    return True;
+}
+
 static void         *dummyGetProcAddress         (const GLubyte *procName)
 {
     int i;
@@ -633,6 +638,7 @@ static const __GLXapiImports dummyImports =
 
     /* Non-entry points */
     .glxvc = {
+        .checkSupportsScreen = dummyCheckSupportsScreen,
         .getProcAddress = dummyGetProcAddress,
         .getDispatchAddress = dummyGetDispatchAddress,
         .setDispatchIndex = dummySetDispatchIndex,


### PR DESCRIPTION
This adds a function to the ABI to determine whether a vendor library will work with a particular X screen.

Once we've got an indirect rendering library as part of libglvnd, other vendor libraries will only have to implement direct rendering. For indirect rendering, they'll be able to just return false and let the indirect rendering library deal with it instead.

Note that this only affects the vendor library selected using the x11glvnd extension. If the user overrides the vendor name with the __GLX_VENDOR_LIBRARY_NAME environment variable, then it'll use that vendor without checking for support.