### PR TITLE
GLX: Fix GLXFBConfig mapping with multiple displays

### DIFF
--- a/src/GLX/libglx.c
+++ b/src/GLX/libglx.c
@@ -131,7 +131,7 @@ static __GLXvendorInfo *CommonDispatchContext(Display *dpy, GLXContext context,
 
     if (context != NULL) {
         __glXThreadInitialize();
-        __glXVendorFromContext(context, NULL, &vendor);
+        __glXVendorFromContext(context, &vendor);
     }
     if (vendor == NULL) {
         __glXSendError(dpy, GLXBadContext, 0, minorCode, False);
@@ -375,7 +375,7 @@ static void glXFreeContextEXT(Display *dpy, GLXContext context)
 
     __glXThreadInitialize();
 
-    __glXVendorFromContext(context, NULL, &vendor);
+    __glXVendorFromContext(context, &vendor);
     if (vendor != NULL && vendor->staticDispatch.freeContextEXT != NULL) {
         __glXNotifyContextDestroyed(context);
         vendor->staticDispatch.freeContextEXT(dpy, context);
@@ -919,7 +919,7 @@ static Bool CommonMakeCurrent(Display *dpy, GLXDrawable draw,
             return False;
         }
 
-        if (__glXVendorFromContext(context, NULL, &newVendor) != 0) {
+        if (__glXVendorFromContext(context, &newVendor) != 0) {
             /*
              * We can run into this corner case if a GLX client calls
              * glXDestroyContext() on a current context, loses current to this

--- a/src/GLX/libglxabi.h
+++ b/src/GLX/libglxabi.h
@@ -121,13 +121,13 @@ typedef struct __GLXapiExportsRec {
      * vendor must be the ones returned for the XVisualInfo or GLXFBConfig that
      * the context is created from.
      */
-    void (*addScreenContextMapping)(Display *dpy, GLXContext context, int screen, __GLXvendorInfo *vendor);
+    void (*addVendorContextMapping)(Display *dpy, GLXContext context, __GLXvendorInfo *vendor);
 
     /*!
      * Removes a mapping from context to vendor. The context must have been
-     * added with \p addScreenContextMapping.
+     * added with \p addVendorContextMapping.
      */
-    void (*removeScreenContextMapping)(Display *dpy, GLXContext context);
+    void (*removeVendorContextMapping)(Display *dpy, GLXContext context);
 
     /*!
      * Looks up the screen and vendor for a context.
@@ -148,7 +148,7 @@ typedef struct __GLXapiExportsRec {
      * \param[out] retVendor Returns the vendor.
      * \return Zero if a match was found, or non-zero if it was not.
      */
-    int (*vendorFromContext)(GLXContext context, Display **retDisplay, int *retScreen, __GLXvendorInfo **retVendor);
+    int (*vendorFromContext)(GLXContext context, Display **retDisplay, __GLXvendorInfo **retVendor);
 
     void (*addScreenFBConfigMapping)(Display *dpy, GLXFBConfig config, int screen, __GLXvendorInfo *vendor);
     void (*removeScreenFBConfigMapping)(Display *dpy, GLXFBConfig config);

--- a/src/GLX/libglxabi.h
+++ b/src/GLX/libglxabi.h
@@ -150,9 +150,9 @@ typedef struct __GLXapiExportsRec {
      */
     int (*vendorFromContext)(GLXContext context, Display **retDisplay, __GLXvendorInfo **retVendor);
 
-    void (*addScreenFBConfigMapping)(Display *dpy, GLXFBConfig config, int screen, __GLXvendorInfo *vendor);
-    void (*removeScreenFBConfigMapping)(Display *dpy, GLXFBConfig config);
-    int (*vendorFromFBConfig)(Display *dpy, GLXFBConfig config, int *retScreen, __GLXvendorInfo **retVendor);
+    void (*addVendorFBConfigMapping)(Display *dpy, GLXFBConfig config, __GLXvendorInfo *vendor);
+    void (*removeVendorFBConfigMapping)(Display *dpy, GLXFBConfig config);
+    int (*vendorFromFBConfig)(Display *dpy, GLXFBConfig config, __GLXvendorInfo **retVendor);
 
     void (*addScreenVisualMapping)(Display *dpy, const XVisualInfo *visual, __GLXvendorInfo *vendor);
     void (*removeScreenVisualMapping)(Display *dpy, const XVisualInfo *visual);

--- a/src/GLX/libglxabi.h
+++ b/src/GLX/libglxabi.h
@@ -178,15 +178,13 @@ typedef struct __GLXapiExportsRec {
      *
      * Note that this function does not take a display connection, since
      * there are cases (e.g., glXGetContextIDEXT) that take a GLXContext but
-     * not a display. Instead, it will return the display that the context was
-     * created on.
+     * not a display.
      *
      * \param context The context to look up.
-     * \param[out] retScreen Returns the screen number.
      * \param[out] retVendor Returns the vendor.
      * \return Zero if a match was found, or non-zero if it was not.
      */
-    int (*vendorFromContext)(GLXContext context, Display **retDisplay, __GLXvendorInfo **retVendor);
+    int (*vendorFromContext)(GLXContext context, __GLXvendorInfo **retVendor);
 
     void (*addVendorFBConfigMapping)(Display *dpy, GLXFBConfig config, __GLXvendorInfo *vendor);
     void (*removeVendorFBConfigMapping)(Display *dpy, GLXFBConfig config);

--- a/src/GLX/libglxabi.h
+++ b/src/GLX/libglxabi.h
@@ -158,20 +158,23 @@ typedef struct __GLXapiExportsRec {
     void (*removeScreenVisualMapping)(Display *dpy, const XVisualInfo *visual);
     int (*vendorFromVisual)(Display *dpy, const XVisualInfo *visual, __GLXvendorInfo **retVendor);
 
-    void (*addScreenDrawableMapping)(Display *dpy, GLXDrawable drawable, int screen, __GLXvendorInfo *vendor);
-    void (*removeScreenDrawableMapping)(Display *dpy, GLXDrawable drawable);
+    void (*addVendorDrawableMapping)(Display *dpy, GLXDrawable drawable, __GLXvendorInfo *vendor);
+    void (*removeVendorDrawableMapping)(Display *dpy, GLXDrawable drawable);
 
     /*!
-     * Looks up the screen and vendor for a drawable.
+     * Looks up the vendor for a drawable.
      *
-     * If the server does not support the x11glvnd extension, then this
-     * function may not be able to determine the screen number for a drawable.
-     * In that case, it will return -1 for the screen number.
+     * If the drawable was created from another GLX function, then this will
+     * return the same vendor library that was used to create it.
      *
-     * Even without x11glvnd, this function will still return a vendor
-     * suitable for indirect rendering.
+     * If the drawable was not created from GLX (a regular X window, for
+     * example), then libGLX.so will use the x11glvnd server extension to
+     * figure out a vendor library.
+     *
+     * All of this should be opaque to a dispatch function, since the only
+     * thing that matters is finding out which vendor to dispatch to.
      */
-    int (*vendorFromDrawable)(Display *dpy, GLXDrawable drawable, int *retScreen, __GLXvendorInfo **retVendor);
+    int (*vendorFromDrawable)(Display *dpy, GLXDrawable drawable, __GLXvendorInfo **retVendor);
 
 } __GLXapiExports;
 

--- a/src/GLX/libglxmapping.c
+++ b/src/GLX/libglxmapping.c
@@ -358,8 +358,8 @@ static void InitExportsTable(void)
     /* We use the real function since __glXGetCurrentContext is inline */
     glxExportsTable.getCurrentContext = glXGetCurrentContext;
 
-    glxExportsTable.addScreenContextMapping = __glXAddScreenContextMapping;
-    glxExportsTable.removeScreenContextMapping = __glXRemoveScreenContextMapping;
+    glxExportsTable.addVendorContextMapping = __glXAddVendorContextMapping;
+    glxExportsTable.removeVendorContextMapping = __glXRemoveVendorContextMapping;
     glxExportsTable.vendorFromContext = __glXVendorFromContext;
 
     glxExportsTable.addScreenFBConfigMapping = __glXAddScreenFBConfigMapping;
@@ -950,21 +950,21 @@ static int DisplayFromPointer(void *ptr, Display **retDisplay, int *retScreen,
 /**
  * Common function for the various __glXVendorFrom* functions.
  */
-void __glXAddScreenContextMapping(Display *dpy, GLXContext context, int screen, __GLXvendorInfo *vendor)
+void __glXAddVendorContextMapping(Display *dpy, GLXContext context, __GLXvendorInfo *vendor)
 {
-    AddScreenPointerMapping(context, dpy, screen, vendor);
+    AddScreenPointerMapping(context, dpy, -1, vendor);
 }
 
 
-void __glXRemoveScreenContextMapping(Display *dpy, GLXContext context)
+void __glXRemoveVendorContextMapping(Display *dpy, GLXContext context)
 {
     RemoveScreenPointerMapping(context);
 }
 
 
-int __glXVendorFromContext(GLXContext context, Display **retDisplay, int *retScreen, __GLXvendorInfo **retVendor)
+int __glXVendorFromContext(GLXContext context, Display **retDisplay, __GLXvendorInfo **retVendor)
 {
-    return DisplayFromPointer(context, retDisplay, retScreen, retVendor, NULL);
+    return DisplayFromPointer(context, retDisplay, NULL, retVendor, NULL);
 }
 
 

--- a/src/GLX/libglxmapping.c
+++ b/src/GLX/libglxmapping.c
@@ -362,8 +362,8 @@ static void InitExportsTable(void)
     glxExportsTable.removeVendorContextMapping = __glXRemoveVendorContextMapping;
     glxExportsTable.vendorFromContext = __glXVendorFromContext;
 
-    glxExportsTable.addScreenFBConfigMapping = __glXAddScreenFBConfigMapping;
-    glxExportsTable.removeScreenFBConfigMapping = __glXRemoveScreenFBConfigMapping;
+    glxExportsTable.addVendorFBConfigMapping = __glXAddVendorFBConfigMapping;
+    glxExportsTable.removeVendorFBConfigMapping = __glXRemoveVendorFBConfigMapping;
     glxExportsTable.vendorFromFBConfig = __glXVendorFromFBConfig;
 
     glxExportsTable.addScreenVisualMapping = __glXAddScreenVisualMapping;
@@ -968,21 +968,21 @@ int __glXVendorFromContext(GLXContext context, Display **retDisplay, __GLXvendor
 }
 
 
-void __glXAddScreenFBConfigMapping(Display *dpy, GLXFBConfig config, int screen, __GLXvendorInfo *vendor)
+void __glXAddVendorFBConfigMapping(Display *dpy, GLXFBConfig config, __GLXvendorInfo *vendor)
 {
-    AddScreenPointerMapping(config, dpy, screen, vendor);
+    AddScreenPointerMapping(config, dpy, -1, vendor);
 }
 
 
-void __glXRemoveScreenFBConfigMapping(Display *dpy, GLXFBConfig config)
+void __glXRemoveVendorFBConfigMapping(Display *dpy, GLXFBConfig config)
 {
     RemoveScreenPointerMapping(config);
 }
 
 
-int __glXVendorFromFBConfig(Display *dpy, GLXFBConfig config, int *retScreen, __GLXvendorInfo **retVendor)
+int __glXVendorFromFBConfig(Display *dpy, GLXFBConfig config, __GLXvendorInfo **retVendor)
 {
-    return DisplayFromPointer(config, NULL, retScreen, retVendor, dpy);
+    return DisplayFromPointer(config, NULL, NULL, retVendor, dpy);
 }
 
 // Internally, we use the screen number to look up a vendor, so we don't need

--- a/src/GLX/libglxmapping.c
+++ b/src/GLX/libglxmapping.c
@@ -876,7 +876,10 @@ static void AddVendorPointerMapping(__GLXvendorPointerHashtable *table,
         pEntry->vendor = vendor;
         HASH_ADD_PTR(_LH(*table), ptr, pEntry);
     } else {
-        pEntry->vendor = vendor;
+        // Any GLXContext or GLXFBConfig handles must be unique to a single
+        // vendor at a time. If we get two different vendors, then there's
+        // either a bug in libGLX or in at least one of the vendor libraries.
+        assert(pEntry->vendor == vendor);
     }
 
     LKDHASH_UNLOCK(__glXPthreadFuncs, *table);
@@ -1008,7 +1011,9 @@ static void AddVendorXIDMapping(Display *dpy, __GLXdisplayInfo *dpyInfo, XID xid
         pEntry->vendor = vendor;
         HASH_ADD(hh, _LH(dpyInfo->xidVendorHash), xid, sizeof(xid), pEntry);
     } else {
-        pEntry->vendor = vendor;
+        // Like GLXContext and GLXFBConfig handles, any GLXDrawables must map
+        // to a single vendor library.
+        assert(pEntry->vendor == vendor);
     }
 
     LKDHASH_UNLOCK(__glXPthreadFuncs, dpyInfo->xidVendorHash);

--- a/src/GLX/libglxmapping.c
+++ b/src/GLX/libglxmapping.c
@@ -370,8 +370,8 @@ static void InitExportsTable(void)
     glxExportsTable.removeScreenVisualMapping = __glXRemoveScreenVisualMapping;
     glxExportsTable.vendorFromVisual = __glXVendorFromVisual;
 
-    glxExportsTable.addScreenDrawableMapping = __glXAddScreenDrawableMapping;
-    glxExportsTable.removeScreenDrawableMapping = __glXRemoveScreenDrawableMapping;
+    glxExportsTable.addVendorDrawableMapping = __glXAddVendorDrawableMapping;
+    glxExportsTable.removeVendorDrawableMapping = __glXRemoveVendorDrawableMapping;
     glxExportsTable.vendorFromDrawable = __glXVendorFromDrawable;
 
 }
@@ -1091,7 +1091,7 @@ static void ScreenFromXID(Display *dpy, __GLXdisplayInfo *dpyInfo, XID xid,
 }
 
 
-void __glXAddScreenDrawableMapping(Display *dpy, GLXDrawable drawable, int screen, __GLXvendorInfo *vendor)
+void __glXAddVendorDrawableMapping(Display *dpy, GLXDrawable drawable, __GLXvendorInfo *vendor)
 {
     __GLXdisplayInfo *dpyInfo = __glXLookupDisplay(dpy);
     if (dpyInfo != NULL) {
@@ -1100,7 +1100,7 @@ void __glXAddScreenDrawableMapping(Display *dpy, GLXDrawable drawable, int scree
 }
 
 
-void __glXRemoveScreenDrawableMapping(Display *dpy, GLXDrawable drawable)
+void __glXRemoveVendorDrawableMapping(Display *dpy, GLXDrawable drawable)
 {
     __GLXdisplayInfo *dpyInfo = __glXLookupDisplay(dpy);
     if (dpyInfo != NULL) {
@@ -1109,7 +1109,7 @@ void __glXRemoveScreenDrawableMapping(Display *dpy, GLXDrawable drawable)
 }
 
 
-int __glXVendorFromDrawable(Display *dpy, GLXDrawable drawable, int *retScreen, __GLXvendorInfo **retVendor)
+int __glXVendorFromDrawable(Display *dpy, GLXDrawable drawable, __GLXvendorInfo **retVendor)
 {
     __GLXdisplayInfo *dpyInfo = __glXLookupDisplay(dpy);
     __GLXvendorInfo *vendor = NULL;
@@ -1122,9 +1122,6 @@ int __glXVendorFromDrawable(Display *dpy, GLXDrawable drawable, int *retScreen, 
         }
     }
 
-    if (retScreen != NULL) {
-        *retScreen = -1;
-    }
     if (retVendor != NULL) {
         *retVendor = vendor;
     }

--- a/src/GLX/libglxmapping.h
+++ b/src/GLX/libglxmapping.h
@@ -97,9 +97,9 @@ __GLdispatchTable *__glXGetGLDispatch(Display *dpy, const int screen);
  * Various functions to manage mappings used to determine the screen
  * of a particular GLX call.
  */
-void __glXAddScreenContextMapping(Display *dpy, GLXContext context, int screen, __GLXvendorInfo *vendor);
-void __glXRemoveScreenContextMapping(Display *dpy, GLXContext context);
-int __glXVendorFromContext(GLXContext context, Display **retDisplay, int *retScreen, __GLXvendorInfo **retVendor);
+void __glXAddVendorContextMapping(Display *dpy, GLXContext context, __GLXvendorInfo *vendor);
+void __glXRemoveVendorContextMapping(Display *dpy, GLXContext context);
+int __glXVendorFromContext(GLXContext context, Display **retDisplay, __GLXvendorInfo **retVendor);
 
 void __glXAddScreenFBConfigMapping(Display *dpy, GLXFBConfig config, int screen, __GLXvendorInfo *vendor);
 void __glXRemoveScreenFBConfigMapping(Display *dpy, GLXFBConfig config);

--- a/src/GLX/libglxmapping.h
+++ b/src/GLX/libglxmapping.h
@@ -52,7 +52,7 @@ struct __GLXvendorInfoRec {
     __GLXdispatchTableStatic staticDispatch; //< static GLX dispatch table
 };
 
-typedef struct __GLXscreenXIDMappingHashRec __GLXscreenXIDMappingHash;
+typedef struct __GLXvendorXIDMappingHashRec __GLXvendorXIDMappingHash;
 
 /*!
  * Structure containing per-display information.
@@ -68,7 +68,7 @@ typedef struct __GLXdisplayInfoRec {
     __GLXvendorInfo **vendors;
     glvnd_rwlock_t vendorLock;
 
-    DEFINE_LKDHASH(__GLXscreenXIDMappingHash, xidScreenHash);
+    DEFINE_LKDHASH(__GLXvendorXIDMappingHash, xidVendorHash);
 
     /// True if the server supports the GLX extension.
     Bool glxSupported;

--- a/src/GLX/libglxmapping.h
+++ b/src/GLX/libglxmapping.h
@@ -109,9 +109,9 @@ void __glXAddScreenVisualMapping(Display *dpy, const XVisualInfo *visual, __GLXv
 void __glXRemoveScreenVisualMapping(Display *dpy, const XVisualInfo *visual);
 int __glXVendorFromVisual(Display *dpy, const XVisualInfo *visual, __GLXvendorInfo **retVendor);
 
-void __glXAddScreenDrawableMapping(Display *dpy, GLXDrawable drawable, int screen, __GLXvendorInfo *vendor);
-void __glXRemoveScreenDrawableMapping(Display *dpy, GLXDrawable drawable);
-int __glXVendorFromDrawable(Display *dpy, GLXDrawable drawable, int *retScreen, __GLXvendorInfo **retVendor);
+void __glXAddVendorDrawableMapping(Display *dpy, GLXDrawable drawable, __GLXvendorInfo *vendor);
+void __glXRemoveVendorDrawableMapping(Display *dpy, GLXDrawable drawable);
+int __glXVendorFromDrawable(Display *dpy, GLXDrawable drawable, __GLXvendorInfo **retVendor);
 
 __GLXextFuncPtr __glXGetGLXDispatchAddress(const GLubyte *procName);
 __GLXextFuncPtr __glXGenerateGLXEntrypoint(const GLubyte *procName);

--- a/src/GLX/libglxmapping.h
+++ b/src/GLX/libglxmapping.h
@@ -99,7 +99,7 @@ __GLdispatchTable *__glXGetGLDispatch(Display *dpy, const int screen);
  */
 void __glXAddVendorContextMapping(Display *dpy, GLXContext context, __GLXvendorInfo *vendor);
 void __glXRemoveVendorContextMapping(Display *dpy, GLXContext context);
-int __glXVendorFromContext(GLXContext context, Display **retDisplay, __GLXvendorInfo **retVendor);
+int __glXVendorFromContext(GLXContext context, __GLXvendorInfo **retVendor);
 
 void __glXAddVendorFBConfigMapping(Display *dpy, GLXFBConfig config, __GLXvendorInfo *vendor);
 void __glXRemoveVendorFBConfigMapping(Display *dpy, GLXFBConfig config);

--- a/src/GLX/libglxmapping.h
+++ b/src/GLX/libglxmapping.h
@@ -101,9 +101,9 @@ void __glXAddVendorContextMapping(Display *dpy, GLXContext context, __GLXvendorI
 void __glXRemoveVendorContextMapping(Display *dpy, GLXContext context);
 int __glXVendorFromContext(GLXContext context, Display **retDisplay, __GLXvendorInfo **retVendor);
 
-void __glXAddScreenFBConfigMapping(Display *dpy, GLXFBConfig config, int screen, __GLXvendorInfo *vendor);
-void __glXRemoveScreenFBConfigMapping(Display *dpy, GLXFBConfig config);
-int __glXVendorFromFBConfig(Display *dpy, GLXFBConfig config, int *retScreen, __GLXvendorInfo **retVendor);
+void __glXAddVendorFBConfigMapping(Display *dpy, GLXFBConfig config, __GLXvendorInfo *vendor);
+void __glXRemoveVendorFBConfigMapping(Display *dpy, GLXFBConfig config);
+int __glXVendorFromFBConfig(Display *dpy, GLXFBConfig config, __GLXvendorInfo **retVendor);
 
 void __glXAddScreenVisualMapping(Display *dpy, const XVisualInfo *visual, __GLXvendorInfo *vendor);
 void __glXRemoveScreenVisualMapping(Display *dpy, const XVisualInfo *visual);


### PR DESCRIPTION
Apparently, there are some applications that depend on being able to look up a GLXFBConfig handle from one display connection, and then use that config on another display. Libglvnd can't currently deal with that, because it expects those handles to be unique and never used outside whatever display they came from.

These changes are to make libglvnd more flexible (or at least, more robust) to that sort of behavior. Most of this is simply to change the bookkeeping and the ABI so that libGLX keeps a mapping from GLX objects (drawables, contexts, configs) directly to vendors, without keeping track of the display or screen for any of them.

For dispatching to work, GLXContext and GLXFBConfig handles must be unique between vendor libraries. That is, two vendor libraries must never produce the same GLXContext or GLXFBConfig handle.

A single vendor library may, however, produce the same GLXFBConfig handle for different displays, possibly to different X servers. For instance, a vendor might use keep track of configs internally by their XID, so it could just have a mapping between XID values and GLXFBConfig handles. The same GLXFBConfig handle might then be used with different displays, and possibly different screens. As long as the GLXFBConfig handles are unique to a vendor, though, then libGLX can just dispatch everything to the correct vendor and not care about anything else.

Without keeping track of a screen number for GLXFBConfigs, we also can't record the screen for a GLXContext, since glXCreateNewContext takes a GLXFBConfig instead of a screen. Same thing with GLXDrawables, where without the x11glvnd extension, we can't find a screen number even now. In both cases, though, we still don't really need a screen, we just need a vendor, so that's what libGLX should keep track of.

That just leaves the issue of making sure that GLXContext and GLXFBConfig handles are unique between vendors. To do that, libGLX now specifies that the handles must be a real memory address. It doesn't matter what address it is, as long as it's something unique to the vendor library.
