### PR TITLE
Small pkg-config, autotools and README.md fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ future this library may support EGL and OpenGL ES as well.
 Building the library
 ----------------------
 
+libglvnd build-depends on xorg-server, libx11, glproto and libxext.
+On Debian and derivatives, run:
+
+    sudo apt-get install xserver-xorg-dev libxext-dev libx11-dev x11proto-gl-dev
+
 Run `./autogen.sh`, then run `./configure` and `make`.
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -158,6 +158,7 @@ AX_PTHREAD()
 PKG_CHECK_MODULES([X11], [x11])
 PKG_CHECK_MODULES([XEXT], [xext])
 PKG_CHECK_MODULES([XORG], [xorg-server >= 1.11.0])
+PKG_CHECK_MODULES([GLPROTO], [glproto])
 
 dnl Checks for header files.
 AC_PATH_X

--- a/src/GLX/Makefile.am
+++ b/src/GLX/Makefile.am
@@ -69,6 +69,8 @@ libGLX_la_LDFLAGS = -shared -Wl,-Bsymbolic -version-info 0 $(LINKER_FLAG_NO_UNDE
 
 BUILT_SOURCES = g_libglxnoop.c
 
+CLEANFILES = $(BUILT_SOURCES)
+
 EXTRA_DIST = gen_stubs.pl glx_funcs.spec
 
 g_libglxnoop.c : gen_stubs.pl glx_funcs.spec

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,3 +8,6 @@ SUBDIRS = util \
 	GL
 
 EXTRA_DIST = generate
+
+clean-local:
+	rm -f generate/*.pyc


### PR DESCRIPTION
Hi,

Few tiny fixes:

- check for glproto in configure.ac, make check tests fail to build without it
- remove autogenerated sources and .pyc files on make clean
- document build dependencies in README