### PR TITLE
libGLdispatch: Fix PIC on x86_64 TSD.

### DIFF
--- a/src/GLdispatch/vnd-glapi/mapi/entry_x86_64_tsd.c
+++ b/src/GLdispatch/vnd-glapi/mapi/entry_x86_64_tsd.c
@@ -52,18 +52,26 @@ __asm__(".balign 4096\n"
    ".balign " U_STRINGIFY(X86_64_ENTRY_SIZE) "\n"                   \
    func ":"
 
-#define STUB_ASM_CODE(slot)         \
-    "movabs _glapi_Current, %rax\n\t" \
+/*
+ * Note that this stub does not exactly match the machine code in
+ * ENTRY_TEMPLATE[] below.  In particular, we take advantage of the GOT and PLT
+ * to produce RIP-relative relocations for the stubs stamped out by mapi_tmp.h.
+ * We can't do that in general for the generated stubs since they're emitted
+ * into malloc()ed memory which may not be within 2GB of %rip, as explained in
+ * the comment in u_execmem.c.
+ */
+#define STUB_ASM_CODE(slot) \
+    "movq _glapi_Current@GOTPCREL(%rip), %rax\n\t" \
+    "movq (%rax), %rax\n" \
     "test %rax, %rax\n\t"           \
     "jne 1f\n\t"                      \
-    "movabs $_glapi_get_current, %rax\n" \
     "push %rdi\n" \
     "push %rsi\n" \
     "push %rdx\n" \
     "push %rcx\n" \
     "push %r8\n" \
     "push %r9\n" \
-    "callq *%rax\n" \
+    "call _glapi_get_current@PLT\n" \
     "pop %r9\n" \
     "pop %r8\n" \
     "pop %rcx\n" \


### PR DESCRIPTION
This makes the built-in x86_64 TSD stubs use RIP-relative addressing so
that the linker doesn't have to generate relocations of text sections,
which breaks PIC.

Fixes #53