### PR TITLE
Use -avoid-version for x11glvnd in x11glvnd_la_LDFLAGS

### DIFF
--- a/src/x11glvnd/Makefile.am
+++ b/src/x11glvnd/Makefile.am
@@ -53,7 +53,7 @@ x11glvnd_la_CFLAGS = \
 	$(INCLUDES)
 
 x11glvnd_la_LDFLAGS = \
-	-shared -module
+	-module -avoid-version
 
 x11glvnd_la_SOURCES = \
 	x11glvndserver.c


### PR DESCRIPTION
This patch also removes the -shared LDFLAGS
redundant with the libtool -module option
(in-sync with others x11 module/drivers)