### PR TITLE
[RFC] Enable x11glvnd by default on more recent xorg release

### DIFF
--- a/src/x11glvnd/x11glvndserver.c
+++ b/src/x11glvnd/x11glvndserver.c
@@ -185,7 +185,7 @@ static void *glvSetup(void *module, void *opts, int *errmaj, int *errmin)
     }
 
 #if XGLV_ABI_HAS_LOAD_EXTENSION_LIST
-    LoadExtensionList(&glvExtensionModule, 1, False);
+    LoadExtensionList(&glvExtensionModule, 1, TRUE);
 #else
     LoadExtension(&glvExtensionModule, False);
 #endif


### PR DESCRIPTION
I'm not sure to understand if libglvnd will work on any (unpatched) older xorg-server release than current. (I remember some issue addressed during the xorg-x11 1.18 development cycle).

But at least, instead of dropping a file into the xorg.conf.d directory to enable the xorg module, enable it by default so it doesn't have to rely on users tweaking their configuration files.

This will greatly help nvidia driver re-packager