### PR TITLE
GLX: Use QueryServerString to get the vendor name

### DIFF
--- a/src/GLX/libglxmapping.c
+++ b/src/GLX/libglxmapping.c
@@ -1023,6 +1023,9 @@ static void RemoveVendorXIDMapping(Display *dpy, __GLXdisplayInfo *dpyInfo, XID 
 
 static int ScreenFromXID(Display *dpy, __GLXdisplayInfo *dpyInfo, XID xid)
 {
+    if (ScreenCount(dpy) == 1)
+        return DefaultScreen(dpy);
+
     if (dpyInfo->x11glvndSupported)
         return XGLVQueryXIDScreenMapping(dpy, xid);
 

--- a/src/GLX/libglxmapping.c
+++ b/src/GLX/libglxmapping.c
@@ -1021,6 +1021,13 @@ static void RemoveVendorXIDMapping(Display *dpy, __GLXdisplayInfo *dpyInfo, XID 
     LKDHASH_UNLOCK(dpyInfo->xidVendorHash);
 }
 
+static int ScreenFromXID(Display *dpy, __GLXdisplayInfo *dpyInfo, XID xid)
+{
+    if (dpyInfo->x11glvndSupported)
+        return XGLVQueryXIDScreenMapping(dpy, xid);
+
+    return -1;
+}
 
 static void VendorFromXID(Display *dpy, __GLXdisplayInfo *dpyInfo, XID xid,
         __GLXvendorInfo **retVendor)
@@ -1036,15 +1043,14 @@ static void VendorFromXID(Display *dpy, __GLXdisplayInfo *dpyInfo, XID xid,
         vendor = pEntry->vendor;
         LKDHASH_UNLOCK(dpyInfo->xidVendorHash);
     } else {
+        int screen;
         LKDHASH_UNLOCK(dpyInfo->xidVendorHash);
 
-        if (dpyInfo->x11glvndSupported) {
-            int screen = XGLVQueryXIDScreenMapping(dpy, xid);
-            if (screen >= 0 && screen < ScreenCount(dpy)) {
-                vendor = __glXLookupVendorByScreen(dpy, screen);
-                if (vendor != NULL) {
-                    AddVendorXIDMapping(dpy, dpyInfo, xid, vendor);
-                }
+        screen = ScreenFromXID(dpy, dpyInfo, xid);
+        if (screen >= 0 && screen < ScreenCount(dpy)) {
+            vendor = __glXLookupVendorByScreen(dpy, screen);
+            if (vendor != NULL) {
+                AddVendorXIDMapping(dpy, dpyInfo, xid, vendor);
             }
         }
     }

--- a/src/GLX/libglxmapping.c
+++ b/src/GLX/libglxmapping.c
@@ -49,6 +49,7 @@
 #include "lkdhash.h"
 #include "x11glvnd.h"
 
+#include "GL/glxproto.h"
 #define _GNU_SOURCE 1
 
 #if !defined(FALLBACK_VENDOR_NAME)
@@ -559,6 +560,61 @@ fail:
     return NULL;
 }
 
+static char *
+__glXQueryServerVendorDriver(Display *dpy, const int screen)
+{
+    xGLXQueryServerStringReq *req;
+    xGLXSingleReply rep;
+    char *ret = NULL;
+    int length;
+    __GLXdisplayInfo *dpyInfo = __glXLookupDisplay(dpy);
+
+    LockDisplay(dpy);
+
+    GetReq(GLXQueryServerString, req);
+    req->reqType = dpyInfo->glxMajorOpcode;
+    req->glxCode = X_GLXQueryServerString;
+    req->screen = screen;
+    req->name = GLX_VERSION;
+
+    if (!_XReply(dpy, (xReply *)&rep, 0, False)) {
+        goto out;
+    }
+
+    length = rep.length * 4;
+    ret = malloc(rep.size);
+    if (ret) {
+        _XRead(dpy, ret, rep.size);
+        length -= rep.size;
+    }
+    _XEatData(dpy, length);
+
+out:
+    UnlockDisplay(dpy);
+    SyncHandle();
+
+    return ret;
+}
+
+static char *
+__glXMatchVendorFromScreen(Display *dpy, const int screen)
+{
+    char *reply, *g;
+
+    /* ask the server for the driver string */
+    reply = __glXQueryServerVendorDriver(dpy, screen);
+    if (!reply)
+        return NULL;
+
+    g = strstr(reply, "glvnd:");
+    if (g) {
+        g += strlen("glvnd:");
+        memmove(reply, g, strlen(g) + 1);
+    }
+
+    return reply;
+}
+
 __GLXvendorInfo *__glXLookupVendorByScreen(Display *dpy, const int screen)
 {
     __GLXvendorInfo *vendor = NULL;
@@ -593,6 +649,26 @@ __GLXvendorInfo *__glXLookupVendorByScreen(Display *dpy, const int screen)
 
         if (preloadedVendorName) {
             vendor = __glXLookupVendorByName(preloadedVendorName);
+        }
+
+        if (!vendor) {
+            int l;
+            char *v;
+            char *reply = __glXMatchVendorFromScreen(dpy, screen);
+
+            v = reply;
+            while ((l = strcspn(v, " ,")) != 0) {
+                    v[l] = '\0';
+                    vendor = __glXLookupVendorByName(v);
+                    if (vendor)
+                        break;
+                    v += l + 1;
+            }
+            free(reply);
+
+            if (vendor != NULL && !vendor->glxvc->checkSupportsScreen(dpy, screen)) {
+                vendor = NULL;
+            }
         }
 
         if (!vendor) {


### PR DESCRIPTION
I'm really not a fan of the x11glvnd extension. QueryServerString has all the properties we'd need to get the same answer: it's server state, it's per-screen, and you don't need a GLX context for it to work.

Given that, and that the server half of the implementation is absolutely trivial, how about we start with something like this? If we wanted a bit more flexibility we could add mapping files in say /etc/glvnd to map from the response string to the vendor name. We'd also want to nail down the exact format of the response string (perhaps a space-separated list of names to iterate over), and to document the whole thing at the GLX spec level. But I'd take all of that over adding an X extension just to avoid extending GLX.