### PR TITLE
GLdispatch: Emit public_entry_{start,end} as hidden symbols

### DIFF
--- a/src/GLdispatch/vnd-glapi/mapi/entry_armv7_tsd.c
+++ b/src/GLdispatch/vnd-glapi/mapi/entry_armv7_tsd.c
@@ -140,6 +140,7 @@ static unsigned char BYTECODE_TEMPLATE[] =
 __asm__(".section wtext,\"ax\"\n"
         ".balign 4096\n"
        ".globl public_entry_start\n"
+       ".hidden public_entry_start\n"
         "public_entry_start:\n");
 
 #define MAPI_TMP_STUB_ASM_GCC
@@ -147,6 +148,7 @@ __asm__(".section wtext,\"ax\"\n"
 
 __asm__(".balign 4096\n"
        ".globl public_entry_end\n"
+       ".hidden public_entry_end\n"
         "public_entry_end:\n"
         ".text\n\t");
 

--- a/src/GLdispatch/vnd-glapi/mapi/entry_x86_64_tls.c
+++ b/src/GLdispatch/vnd-glapi/mapi/entry_x86_64_tls.c
@@ -44,6 +44,7 @@
 __asm__(".section wtext,\"ax\",@progbits\n");
 __asm__(".balign 4096\n"
        ".globl public_entry_start\n"
+       ".hidden public_entry_start\n"
         "public_entry_start:");
 
 #define STUB_ASM_ENTRY(func)                             \
@@ -62,6 +63,7 @@ __asm__(".balign 4096\n"
 
 __asm__(".balign 4096\n"
        ".globl public_entry_end\n"
+       ".hidden public_entry_end\n"
         "public_entry_end:");
 
 __asm__(".text\n");

--- a/src/GLdispatch/vnd-glapi/mapi/entry_x86_64_tsd.c
+++ b/src/GLdispatch/vnd-glapi/mapi/entry_x86_64_tsd.c
@@ -44,6 +44,7 @@
 __asm__(".section wtext,\"ax\",@progbits\n");
 __asm__(".balign 4096\n"
        ".globl public_entry_start\n"
+       ".hidden public_entry_start\n"
         "public_entry_start:");
 
 #define STUB_ASM_ENTRY(func)        \
@@ -87,6 +88,7 @@ __asm__(".balign 4096\n"
 
 __asm__(".balign 4096\n"
        ".globl public_entry_end\n"
+       ".hidden public_entry_end\n"
         "public_entry_end:");
 __asm__(".text\n");
 

--- a/src/GLdispatch/vnd-glapi/mapi/entry_x86_tsd.c
+++ b/src/GLdispatch/vnd-glapi/mapi/entry_x86_tsd.c
@@ -42,6 +42,7 @@
 __asm__(".section wtext,\"ax\",@progbits\n");
 __asm__(".balign 4096\n"
        ".globl public_entry_start\n"
+       ".hidden public_entry_start\n"
         "public_entry_start:");
 
 #define STUB_ASM_ENTRY(func)        \
@@ -65,6 +66,7 @@ __asm__(".balign 4096\n"
 
 __asm__(".balign 4096\n"
        ".globl public_entry_end\n"
+       ".hidden public_entry_end\n"
         "public_entry_end:");
 __asm__(".text\n");
 


### PR DESCRIPTION
Issue #61 mentions libGLdispatch and defining visibility for assembly symbols, here's a fix.