### PR TITLE
GLX: Allow different dispatch tables for different contexts.

### DIFF
--- a/src/GLX/libglxmapping.h
+++ b/src/GLX/libglxmapping.h
@@ -47,7 +47,10 @@ struct __GLXvendorInfoRec {
     /// dynamic GLX dispatch table
     DEFINE_LKDHASH(struct __GLXdispatchFuncHashRec, dynDispatchHash);
 
-    __GLdispatchTable *glDispatch; //< GL dispatch table
+    /*!
+     * A hashtable to keep track of the dispatch tables for this vendor.
+     */
+    struct __GLXcontextDispatchHashRec *contextDispatchHash;
 
     const __GLXapiImports *glxvc;
     const __GLdispatchPatchCallbacks *patchCallbacks;
@@ -93,8 +96,6 @@ const __GLXdispatchTableStatic * __glXGetStaticDispatch(Display *dpy,
                                                         const int screen);
 __GLXvendorInfo *__glXGetDynDispatch(Display *dpy,
                                                const int screen);
-__GLdispatchTable *__glXGetGLDispatch(Display *dpy, const int screen);
-
 /*!
  * Various functions to manage mappings used to determine the screen
  * of a particular GLX call.


### PR DESCRIPTION
This is an extension to the libGLX vendor library interface that allows a vendor to provide different dispatch tables for each GLXContext.

It adds two optional callbacks to the __GLXapiImports struct. The first allows the vendor to provide an opaque dispatch table handle for a GLXContext. The second callback is used to populate a dispatch table.

The goal is to allow a library such as Mesa to use libglvnd's dispatch layer instead of having to send every OpenGL function through two layers.
