### PR TITLE
Add pkgconfig data for libraries implemented so far

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -235,10 +235,15 @@ AC_CONFIG_FILES([Makefile
                  libglvnd.pc
                  include/Makefile
                  src/Makefile
+                 src/GL/gl.pc
                  src/GL/Makefile
+                 src/OpenGL/opengl.pc
                  src/OpenGL/Makefile
+                 src/GLESv1/glesv1_cm.pc
                  src/GLESv1/Makefile
+                 src/GLESv2/glesv2.pc
                  src/GLESv2/Makefile
+                 src/GLX/glx.pc
                  src/GLX/Makefile
                  src/GLdispatch/Makefile
                  src/GLdispatch/vnd-glapi/Makefile

--- a/src/GL/Makefile.am
+++ b/src/GL/Makefile.am
@@ -71,3 +71,6 @@ AM_CPPFLAGS = \
 libGL_la_LIBADD  = ../GLX/libGLX.la
 libGL_la_LIBADD += ../GLdispatch/libGLdispatch.la
 libGL_la_LIBADD += -ldl
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = gl.pc

--- a/src/GL/gl.pc.in
+++ b/src/GL/gl.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+includedir=@includedir@
+
+Name: gl
+Description: libglvnd legacy OpenGL library
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lGL
+Cflags: -I${includedir}

--- a/src/GLESv1/Makefile.am
+++ b/src/GLESv1/Makefile.am
@@ -41,3 +41,5 @@ libGLESv1_CM_la_LDFLAGS = $(ENTRYPOINT_COMMON_LDFLAGS) \
 
 libGLESv1_CM_la_LIBADD = $(ENTRYPOINT_COMMON_LIBADD)
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = glesv1_cm.pc

--- a/src/GLESv1/glesv1_cm.pc.in
+++ b/src/GLESv1/glesv1_cm.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+includedir=@includedir@
+
+Name: gl
+Description: libglvnd OpenGL ES v1 library
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lGLESv1_CM
+Cflags: -I${includedir}

--- a/src/GLESv2/Makefile.am
+++ b/src/GLESv2/Makefile.am
@@ -41,3 +41,5 @@ libGLESv2_la_LDFLAGS = $(ENTRYPOINT_COMMON_LDFLAGS) \
 
 libGLESv2_la_LIBADD = $(ENTRYPOINT_COMMON_LIBADD)
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = glesv2.pc

--- a/src/GLESv2/glesv2.pc.in
+++ b/src/GLESv2/glesv2.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+includedir=@includedir@
+
+Name: gles2
+Description: libglvnd OpenGL ES v2+ library
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lGLESv2
+Cflags: -I${includedir}

--- a/src/GLX/Makefile.am
+++ b/src/GLX/Makefile.am
@@ -82,3 +82,6 @@ libGLX_la_SOURCES = \
 	$(UTIL_DIR)/utils_misc.c \
 	$(UTIL_DIR)/app_error_check.c \
 	g_libglxnoop.c
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = glx.pc

--- a/src/GLX/glx.pc.in
+++ b/src/GLX/glx.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+includedir=@includedir@
+
+Name: glx
+Description: libglvnd GLX library
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lGLX
+Cflags: -I${includedir}

--- a/src/OpenGL/Makefile.am
+++ b/src/OpenGL/Makefile.am
@@ -41,3 +41,5 @@ libOpenGL_la_LDFLAGS = $(ENTRYPOINT_COMMON_LDFLAGS) \
 
 libOpenGL_la_LIBADD = $(ENTRYPOINT_COMMON_LIBADD)
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = opengl.pc

--- a/src/OpenGL/opengl.pc.in
+++ b/src/OpenGL/opengl.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+includedir=@includedir@
+
+Name: openg
+Description: libglvnd OpenGL library
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lOpenGL
+Cflags: -I${includedir}


### PR DESCRIPTION
This preserves the names from Mesa's gl, glesv1_cm, and glesv2 pkgconfig
data, and for compatibility with that, gl.pc gives you libGL. If newer
applications want to explicitly depend on libGLX and the appropriate
rendering API they can ask for the new pkgconfig names.
