### PR TITLE
Fix a read after free

### DIFF
--- a/src/GLX/libglx.c
+++ b/src/GLX/libglx.c
@@ -1275,13 +1275,13 @@ static char *MergeExtensionStrings(char *currentString, const char *newString)
     name = newString;
     nameLen = 0;
     while (FindNextExtensionName(&name, &nameLen)) {
-        if (!IsExtensionInString(currentString, name, nameLen)) {
+        if (!IsExtensionInString(buf, name, nameLen)) {
             *ptr++ = ' ';
             memcpy(ptr, name, nameLen);
             ptr += nameLen;
+            *ptr = '\0';
         }
     }
-    *ptr = '\0';
     assert((size_t) (ptr - buf) == newLen);
     return buf;
 }

--- a/src/GLdispatch/vnd-glapi/mapi/mapi_glapi.c
+++ b/src/GLdispatch/vnd-glapi/mapi/mapi_glapi.c
@@ -88,8 +88,8 @@ _glapi_get_stub(const char *name, int generate)
 {
    const struct mapi_stub *stub;
 
-    if (!name)
-        return NULL;
+   if (!name)
+      return NULL;
 
    stub = stub_find_public(name);
    if (!stub)


### PR DESCRIPTION
This fixes a read after the memory has been freed (realloc'ed). There is also a trivial fix to the indentation.

Just let me know if you would like me to do the change in a different way. E.g. do a malloc+free instead of realloc.