### PR TITLE
GLX: Allow vendor library control of the GL dispatch table

### DIFF
--- a/include/glvnd/GLdispatchABI.h
+++ b/include/glvnd/GLdispatchABI.h
@@ -113,6 +113,13 @@ enum {
 typedef GLboolean (*DispatchPatchLookupStubOffset)(const char *funcName,
         void **writePtr, const void **execPtr);
 
+/*!
+ * This opaque structure describes the GL dispatch table.
+ */
+typedef struct __GLdispatchTableRec __GLdispatchTable;
+
+typedef void *(*__GLdispatchGetProcAddressCallback)(const char *procName, void *param);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/include/glvnd/libglxabi.h
+++ b/include/glvnd/libglxabi.h
@@ -119,9 +119,6 @@ static inline uint32_t GLX_VENDOR_ABI_GET_MINOR_VERSION(uint32_t version)
  */
 typedef struct __GLXvendorInfoRec __GLXvendorInfo;
 
-typedef struct __GLXdispatchTableRec __GLXdispatchTable;
-typedef void * (* __GLXdispatchGetProcAddress) (const char *procName, void *param);
-
 /****************************************************************************
  * API library exports                                                      *
  ****************************************************************************/
@@ -242,9 +239,9 @@ typedef struct __GLXapiExportsRec {
      * \param param A parameter to pass to \p callback.
      * \return An opaque dispatch table handle, or \c NULL on error.
      */
-    __GLXdispatchTable * (* createGLDispatchTable) (
+    __GLdispatchTable * (* createGLDispatchTable) (
             __GLXvendorInfo *vendor,
-            __GLXdispatchGetProcAddress callback,
+            __GLdispatchGetProcAddressCallback callback,
             void *param);
 
     /*!
@@ -252,7 +249,7 @@ typedef struct __GLXapiExportsRec {
      *
      * \param dispatch A dispatch table handle.
      */
-    void (* destroyGLDispatchTable) (__GLXdispatchTable *dispatch);
+    void (* destroyGLDispatchTable) (__GLdispatchTable *dispatch);
 
     /*!
      * Sets the current dispatch table.
@@ -265,7 +262,7 @@ typedef struct __GLXapiExportsRec {
      *
      * \param dispatch A dispatch table handle.
      */
-    void (* setGLDispatchTable) (__GLXdispatchTable *dispatch);
+    void (* setGLDispatchTable) (__GLdispatchTable *dispatch);
 } __GLXapiExports;
 
 /*****************************************************************************
@@ -450,7 +447,7 @@ typedef struct __GLXapiImportsRec {
      * either \c X_GLXMakeCurrent or \c X_GLXMakeContextCurrent.
      * \return The dispatch table to use, or \c NULL on error.
      */
-    __GLXdispatchTable * (* makeContextCurrent) (Display *dpy,
+    __GLdispatchTable * (* makeContextCurrent) (Display *dpy,
             GLXDrawable draw, GLXDrawable read, GLXContext ctx, char opcode);
 
 } __GLXapiImports;

--- a/src/GLX/libglxmapping.c
+++ b/src/GLX/libglxmapping.c
@@ -128,6 +128,10 @@ static const __GLXapiExports glxExportsTable = {
     .addVendorDrawableMapping = __glXAddVendorDrawableMapping,
     .removeVendorDrawableMapping = __glXRemoveVendorDrawableMapping,
     .vendorFromDrawable = __glXVendorFromDrawable,
+
+    .createGLDispatchTable = __glXCreateGLDispatchTable,
+    .destroyGLDispatchTable = __glXDestroyGLDispatchTable,
+    .setGLDispatchTable = __glXSetGLDispatchTable,
 };
 
 /*!
@@ -441,15 +445,6 @@ __GLXvendorInfo *__glXLookupVendorByName(const char *vendorName)
             vendor->vendorID = __glDispatchNewVendorID();
             assert(vendor->vendorID >= 0);
 
-            vendor->glDispatch = (__GLdispatchTable *)
-                __glDispatchCreateTable(
-                    VendorGetProcAddressCallback,
-                    vendor
-                );
-            if (!vendor->glDispatch) {
-                goto fail;
-            }
-
             /* Initialize the dynamic dispatch table */
             vendor->dynDispatch = __glvndWinsysVendorDispatchCreate();
             if (vendor->dynDispatch == NULL) {
@@ -474,6 +469,17 @@ __GLXvendorInfo *__glXLookupVendorByName(const char *vendorName)
 
             if (!LookupVendorEntrypoints(vendor)) {
                 goto fail;
+            }
+
+            if (vendor->glxvc->makeContextCurrent == NULL) {
+                vendor->glDispatch = (__GLdispatchTable *)
+                    __glDispatchCreateTable(
+                        VendorGetProcAddressCallback,
+                        vendor
+                    );
+                if (!vendor->glDispatch) {
+                    goto fail;
+                }
             }
 
             // Check to see whether this vendor library can support entrypoint

--- a/src/GLX/libglxmapping.c
+++ b/src/GLX/libglxmapping.c
@@ -130,8 +130,8 @@ static const __GLXapiExports glxExportsTable = {
     .vendorFromDrawable = __glXVendorFromDrawable,
 
     .createGLDispatchTable = __glXCreateGLDispatchTable,
-    .destroyGLDispatchTable = __glXDestroyGLDispatchTable,
-    .setGLDispatchTable = __glXSetGLDispatchTable,
+    .destroyGLDispatchTable = __glDispatchDestroyTable,
+    .setGLDispatchTable = __glDispatchSetDispatch,
 };
 
 /*!
@@ -311,10 +311,9 @@ static void CleanupVendorNameEntry(void *unused,
                                    __GLXvendorNameHash *pEntry)
 {
     __GLXvendorInfo *vendor = &pEntry->vendor;
-    if (vendor->glDispatch != NULL) {
-        __glDispatchDestroyTable(vendor->glDispatch);
-        vendor->glDispatch = NULL;
-    }
+    __glDispatchDestroyVendorTables(vendor->vendorID);
+
+    vendor->glDispatch = NULL;
 
     if (vendor->dynDispatch != NULL) {
         __glvndWinsysVendorDispatchDestroy(vendor->dynDispatch);
@@ -474,9 +473,9 @@ __GLXvendorInfo *__glXLookupVendorByName(const char *vendorName)
             if (vendor->glxvc->makeContextCurrent == NULL) {
                 vendor->glDispatch = (__GLdispatchTable *)
                     __glDispatchCreateTable(
-                        VendorGetProcAddressCallback,
-                        vendor
-                    );
+                            vendor->vendorID,
+                            VendorGetProcAddressCallback,
+                            vendor);
                 if (!vendor->glDispatch) {
                     goto fail;
                 }

--- a/src/GLX/libglxmapping.c
+++ b/src/GLX/libglxmapping.c
@@ -311,7 +311,10 @@ static void CleanupVendorNameEntry(void *unused,
                                    __GLXvendorNameHash *pEntry)
 {
     __GLXvendorInfo *vendor = &pEntry->vendor;
-    __glDispatchDestroyVendorTables(vendor->vendorID);
+    if (vendor->vendorID >= 0) {
+        __glDispatchDestroyVendorTables(vendor->vendorID);
+        vendor->vendorID = -1;
+    }
 
     vendor->glDispatch = NULL;
 
@@ -425,6 +428,7 @@ __GLXvendorInfo *__glXLookupVendorByName(const char *vendorName)
 
             vendor->glxvc = &pEntry->imports;
             vendor->name = (char *) (pEntry + 1);
+            vendor->vendorID = -1;
             memcpy(vendor->name, vendorName, vendorNameLen + 1);
 
             filename = ConstructVendorLibraryFilename(vendorName);

--- a/src/GLX/libglxmapping.h
+++ b/src/GLX/libglxmapping.h
@@ -148,12 +148,9 @@ void __glXMappingInit(void);
  */
 void __glXMappingTeardown(Bool doReset);
 
-__GLXdispatchTable * __glXCreateGLDispatchTable(
+__GLdispatchTable * __glXCreateGLDispatchTable(
         __GLXvendorInfo *vendor,
-        __GLXdispatchGetProcAddress callback,
+        __GLdispatchGetProcAddressCallback callback,
         void *param);
-
-void __glXDestroyGLDispatchTable(__GLXdispatchTable *dispatch);
-void __glXSetGLDispatchTable(__GLXdispatchTable *dispatch);
 
 #endif /* __LIB_GLX_MAPPING_H */

--- a/src/GLX/libglxmapping.h
+++ b/src/GLX/libglxmapping.h
@@ -148,4 +148,12 @@ void __glXMappingInit(void);
  */
 void __glXMappingTeardown(Bool doReset);
 
+__GLXdispatchTable * __glXCreateGLDispatchTable(
+        __GLXvendorInfo *vendor,
+        __GLXdispatchGetProcAddress callback,
+        void *param);
+
+void __glXDestroyGLDispatchTable(__GLXdispatchTable *dispatch);
+void __glXSetGLDispatchTable(__GLXdispatchTable *dispatch);
+
 #endif /* __LIB_GLX_MAPPING_H */

--- a/src/GLdispatch/GLdispatch.h
+++ b/src/GLdispatch/GLdispatch.h
@@ -298,6 +298,22 @@ PUBLIC GLboolean __glDispatchMakeCurrent(__GLdispatchThreadState *threadState,
                                          const __GLdispatchPatchCallbacks *patchCb);
 
 /*!
+ * Sets the dispatch table for the curernt thread. This may only be called when
+ * there's already a current context. The caller is responsible for ensuring
+ * that the dispatch table is compatible with the current context and vendor.
+ *
+ * \param dispatch The new dispatch table. If this is \c NULL, then a no-op
+ * table is used instead.
+ */
+PUBLIC void __glDispatchSetDispatch(__GLdispatchTable *dispatch);
+
+/*!
+ * Returns a pointer to the dispatch table for the current thread, as set by
+ * \c __glDispatchMakeCurrent or \c __glDispatchSetDispatch.
+ */
+PUBLIC __GLdispatchTable *__glDispatchGetCurrentDispatch(void);
+
+/*!
  * This makes the NOP dispatch table current and sets the current thread state
  * to NULL.
  *

--- a/src/GLdispatch/GLdispatch.h
+++ b/src/GLdispatch/GLdispatch.h
@@ -58,7 +58,7 @@
  *
  * \see __glDispatchGetABIVersion
  */
-#define GLDISPATCH_ABI_VERSION 1
+#define GLDISPATCH_ABI_VERSION 2
 
 /* Namespaces for thread state */
 enum {
@@ -66,14 +66,7 @@ enum {
     GLDISPATCH_API_EGL
 };
 
-/*!
- * This opaque structure describes the core GL dispatch table.
- */
-typedef struct __GLdispatchTableRec __GLdispatchTable;
-
 typedef void (*__GLdispatchProc)(void);
-
-typedef void *(*__GLgetProcAddressCallback)(const char *procName, void *param);
 
 /**
  * An opaque structure used for internal thread state data.
@@ -266,7 +259,8 @@ PUBLIC __GLdispatchProc __glDispatchGetProcAddress(const char *procName);
  * \param[in] param A pointer to pass to \p getProcAddress.
  */
 PUBLIC __GLdispatchTable *__glDispatchCreateTable(
-    __GLgetProcAddressCallback getProcAddress,
+    int vendorID,
+    __GLdispatchGetProcAddressCallback getProcAddress,
     void *param
 );
 
@@ -274,6 +268,8 @@ PUBLIC __GLdispatchTable *__glDispatchCreateTable(
  * Destroy a dispatch table in GLdispatch.
  */
 PUBLIC void __glDispatchDestroyTable(__GLdispatchTable *dispatch);
+
+PUBLIC void __glDispatchDestroyVendorTables(int vendorID);
 
 /*!
  * This makes the given thread state current, and assigns this thread state the

--- a/src/GLdispatch/GLdispatchPrivate.h
+++ b/src/GLdispatch/GLdispatchPrivate.h
@@ -41,6 +41,9 @@
  * and updating dispatch tables.
  */
 struct __GLdispatchTableRec {
+    /*! The vendor that created this dispatch table. */
+    int vendorID;
+
     /*! Number of threads this dispatch is current on */
     int currentThreads;
 
@@ -48,7 +51,7 @@ struct __GLdispatchTableRec {
     int generation;
 
     /*! Saved vendor library callbacks */
-    __GLgetProcAddressCallback getProcAddress;
+    __GLdispatchGetProcAddressCallback getProcAddress;
     void *getProcAddressParam;
 
     /*! The real dispatch table */

--- a/src/GLdispatch/export_list.sym
+++ b/src/GLdispatch/export_list.sym
@@ -15,3 +15,5 @@ __glDispatchNewVendorID
 __glDispatchRegisterStubCallbacks
 __glDispatchReset
 __glDispatchUnregisterStubCallbacks
+__glDispatchSetDispatch
+__glDispatchGetCurrentDispatch

--- a/src/GLdispatch/export_list.sym
+++ b/src/GLdispatch/export_list.sym
@@ -17,3 +17,4 @@ __glDispatchReset
 __glDispatchUnregisterStubCallbacks
 __glDispatchSetDispatch
 __glDispatchGetCurrentDispatch
+__glDispatchDestroyVendorTables


### PR DESCRIPTION
This extends the libGLX vendor library interface to give a vendor library more-or-less direct control of the current GL dispatch table.

Rather than just setting a dispatch table for each context like with #85, this allows a vendor library to specify a dispatch table for each glXMakeCurrent call, and allows a vendor library to change the current dispatch table at any time as long as it owns the current context.

libGLX provides a function that the vendor library can call to create a new dispatch table. The vendor can then pass that dispatch table to libGLX to tell it to switch the current dispatch table.

In addition, there's a new optional callback that the vendor can provide to handle glXMakeCurrent calls, which returns the dispatch table to use for the current thread. If the vendor provides that callback, then libGLX will use it instead of the normal per-vendor dispatch table.
