### PR TITLE
Remove uneeded xorg-server dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,6 @@ AX_PTHREAD()
 
 PKG_CHECK_MODULES([X11], [x11])
 PKG_CHECK_MODULES([XEXT], [xext])
-PKG_CHECK_MODULES([XORG], [xorg-server >= 1.11.0])
 PKG_CHECK_MODULES([GLPROTO], [glproto])
 
 dnl Checks for typedefs, structures, and compiler characteristics.


### PR DESCRIPTION
This dependency doesn't seem to be used anymore since the x11glvnd Xorg module has been removed.
An Xorg server might still be needed for make tests.