### PR TITLE
Add a script to generate GLX dispatch stubs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -239,6 +239,7 @@ AC_CONFIG_FILES([Makefile
                  src/GLdispatch/Makefile
                  src/GLdispatch/vnd-glapi/Makefile
                  src/util/Makefile
+                 src/vendor/Makefile
                  tests/Makefile
                  tests/GLX_dummy/Makefile])
 AC_OUTPUT

--- a/src/GLX/Makefile.am
+++ b/src/GLX/Makefile.am
@@ -34,17 +34,21 @@ noinst_HEADERS = \
 	libglxthread.h \
 	libglxproto.h
 
+EXTRA_DIST = libglx_function_list.py
+
 lib_LTLIBRARIES = libGLX.la
 
 UTIL_DIR = ../util
 UTHASH_DIR = ../util/uthash/src
 GL_DISPATCH_DIR = ../GLdispatch
+VENDOR_DIR = ../vendor
 
 # Warning settings
 # Include paths
 libGLX_la_CFLAGS =  -I$(srcdir)/$(UTHASH_DIR)
 libGLX_la_CFLAGS += -I$(srcdir)/$(UTIL_DIR)
 libGLX_la_CFLAGS += -I$(srcdir)/$(GL_DISPATCH_DIR)
+libGLX_la_CFLAGS += -I$(srcdir)/$(VENDOR_DIR)
 libGLX_la_CFLAGS += -I$(top_srcdir)/include
 libGLX_la_CFLAGS += $(GLPROTO_CFLAGS)
 
@@ -62,6 +66,7 @@ libGLX_la_LIBADD += $(UTIL_DIR)/libglvnd_genentry.la
 libGLX_la_LIBADD += $(UTIL_DIR)/libutils_misc.la
 libGLX_la_LIBADD += $(UTIL_DIR)/libapp_error_check.la
 libGLX_la_LIBADD += $(UTIL_DIR)/libwinsys_dispatch.la
+libGLX_la_LIBADD += $(VENDOR_DIR)/libglxdispatchstubs.la
 
 libGLX_la_LDFLAGS = -shared -Wl,-Bsymbolic -version-info 0 $(LINKER_FLAG_NO_UNDEFINED)
 

--- a/src/GLX/libglx_function_list.py
+++ b/src/GLX/libglx_function_list.py
@@ -1,0 +1,189 @@
+#!/usr/bin/python
+
+# Copyright (c) 2016, NVIDIA CORPORATION.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and/or associated documentation files (the
+# "Materials"), to deal in the Materials without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Materials, and to
+# permit persons to whom the Materials are furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# unaltered in all copies or substantial portions of the Materials.
+# Any additions, deletions, or changes to the original source files
+# must be clearly indicated in accompanying documentation.
+#
+# If only executable code is distributed, then the accompanying
+# documentation must state that "this software is based in part on the
+# work of the Khronos Group."
+#
+# THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+"""
+The GLX function list, used by gen_glx_dispatch.py.
+
+GLX Function values:
+- "method"
+    How to select a vendor library. See "Method values" below.
+
+- "add_mapping"
+    Specifies that the return value should be added to one of libGLX's
+    mappings. See "add_mapping values" below.
+
+- "remove_mapping"
+    Specifies that the return value should be removed to one of libGLX's
+    mappings.
+
+    Allowed values are "context", "drawable", and "config".
+
+- "remove_key"
+    The parameter that contains the value to remove from libGLX's mapping.
+    If unspecified, the default is the same as the "key" field.
+
+- "prefix"
+    If True, the function should be exported from the library. This is used for
+    generating dispatch stubs for libGLX itself -- vendor libraries generally
+    should not use it.
+
+- "static"
+    If this is True, then the function will be declared static.
+
+- "public"
+    If True, the function should be exported from the library. Vendor libraries
+    generally should not use this.
+
+- "display"
+    The name of the parameter that contains the Display pointer.
+    May be "<current>" to specify the current display.
+    If not specified, it will look for a parameter with the correct type.
+
+- "extension"
+    The name of an extension macro to check for before defining the function.
+
+- "inheader"
+    If True, then this function should be declared in the generated header
+    file.
+
+method values:
+- "custom"
+    The dispatch stub will be hand-written instead of generated.
+
+- "none"
+    No dispatch function exists at all, but the function should still have an
+    entry in the index array. This is for other functions that a stub may need
+    to call that are implemented in libGLX itself.
+
+- "current"
+    Use the current context.
+
+- "drawable", "context", "config"
+    Look up by a GLXDrawable, GLXContext, or GLXFBConfig parameter.
+    The parameter is given by the "key" field. If unspecified, it will use the
+    first parameter of the correct type that it finds.
+
+- "screen"
+    Get a screen number from a parameter.
+    The parameter name is given by the "key" field. If unspecifid, the default
+    parameter name is "screen".
+
+- "xvisinfo"
+    Use an XVisualInfo pointer from a parameter.
+    The parameter name is given by the "key" field. If unspecifid, it will look
+    for the first XVisualInfo parameter.
+
+add_mapping values:
+- "context", "drawable", "config"
+    Adds the returned GLXContext, GLXDrawable, or GLXConfig.
+
+- "config_list"
+    Adds an array of GLXFBConfig values. In this case, you also need to specify
+    a pointer to the item count in the "nelements" field.
+"""
+
+
+def _glxFunc(name, method, opcode=None, error=None, prefix="",
+        display=None, key=None, extension=None, retval=None, static=False,
+        public=True, inheader=None, add_mapping=None, nelements=None,
+        remove_mapping=None, remove_key=None):
+
+    if (inheader == None):
+        # The public functions are already declared in glx.h.
+        inheader = (not public)
+    values = {
+        "method" : method,
+        "opcode" : opcode,
+        "error" : error,
+        "key" : key,
+        "prefix" : prefix,
+        "display" : display,
+        "extension" : extension,
+        "retval" : retval,
+        "static" : static,
+        "public" : public,
+        "inheader" : inheader,
+        "add_mapping" : add_mapping,
+        "nelements" : nelements,
+        "remove_mapping" : remove_mapping,
+        "remove_key" : remove_key,
+    }
+    return (name, values)
+
+# This list contains all of the GLX functions that are implemented in libGLX
+# itself. In addition to generating some of the dispatch functions, this list
+# is also used to populate the GLX dispatch index list.
+
+GLX_FUNCTIONS = (
+    _glxFunc("glXChooseFBConfig", "screen", "X_GLXGetFBConfigs", add_mapping="config_list", nelements=3),
+    _glxFunc("glXCreateContext", "xvisinfo", "X_GLXCreateContext", add_mapping="context"),
+    _glxFunc("glXCreateGLXPixmap", "xvisinfo", "X_GLXCreateGLXPixmap", add_mapping="drawable"),
+    _glxFunc("glXCreateNewContext", "config", "X_GLXCreateNewContext", add_mapping="context"),
+    _glxFunc("glXCreatePbuffer", "config", "X_GLXCreatePbuffer", add_mapping="drawable"),
+    _glxFunc("glXCreatePixmap", "config", "X_GLXCreatePixmap", add_mapping="drawable"),
+    _glxFunc("glXCreateWindow", "config", "X_GLXCreateWindow", add_mapping="drawable"),
+    _glxFunc("glXDestroyGLXPixmap", "drawable", "X_GLXDestroyGLXPixmap", error="GLXBadPixmap", remove_mapping="drawable"),
+    _glxFunc("glXDestroyPbuffer", "drawable", "X_GLXDestroyPbuffer", error="GLXBadPbuffer", remove_mapping="drawable"),
+    _glxFunc("glXDestroyPixmap", "drawable", "X_GLXDestroyPixmap", error="GLXBadPixmap", remove_mapping="drawable"),
+    _glxFunc("glXDestroyWindow", "drawable", "X_GLXDestroyWindow", error="GLXBadWindow", remove_mapping="drawable"),
+    _glxFunc("glXGetConfig", "xvisinfo", "X_GLXGetFBConfigs"),
+    _glxFunc("glXChooseVisual", "screen", "X_GLXGetVisualConfigs"),
+    _glxFunc("glXCopyContext", "context", "X_GLXCopyContext"),
+    _glxFunc("glXGetFBConfigAttrib", "config", "X_GLXGetFBConfigs"),
+    _glxFunc("glXGetFBConfigs", "screen", "X_GLXGetFBConfigs", add_mapping="config_list", nelements=2),
+    _glxFunc("glXGetSelectedEvent", "drawable", "X_GLXGetDrawableAttributes", error="GLXBadDrawable"),
+    _glxFunc("glXGetVisualFromFBConfig", "config", "X_GLXGetFBConfigs"),
+    _glxFunc("glXIsDirect", "context", "X_GLXIsDirect"),
+    _glxFunc("glXQueryExtensionsString", "screen", "X_GLXQueryServerString"),
+    _glxFunc("glXQueryServerString", "screen", "X_GLXQueryServerString"),
+    _glxFunc("glXQueryContext", "context", "X_GLXQueryContext"),
+    _glxFunc("glXQueryDrawable", "drawable", "X_GLXGetDrawableAttributes", error="GLXBadDrawable"),
+    _glxFunc("glXSelectEvent", "drawable", "X_GLXChangeDrawableAttributes", error="GLXBadDrawable"),
+    _glxFunc("glXSwapBuffers", "drawable", "X_GLXSwapBuffers", error="GLXBadDrawable"),
+    _glxFunc("glXUseXFont", "current", "X_GLXUseXFont"),
+    _glxFunc("glXWaitGL", "current", "X_GLXWaitGL"),
+    _glxFunc("glXWaitX", "current", "X_GLXWaitX"),
+
+    _glxFunc("glXDestroyContext", "custom"),
+    _glxFunc("glXGetClientString", "custom"),
+    _glxFunc("glXGetCurrentContext", "custom"),
+    _glxFunc("glXGetCurrentDisplay", "custom"),
+    _glxFunc("glXGetCurrentDrawable", "custom"),
+    _glxFunc("glXGetCurrentReadDrawable", "custom"),
+    _glxFunc("glXGetProcAddress", "custom"),
+    _glxFunc("glXGetProcAddressARB", "custom"),
+    _glxFunc("glXMakeContextCurrent", "custom"),
+    _glxFunc("glXMakeCurrent", "custom"),
+    _glxFunc("glXQueryExtension", "custom"),
+    _glxFunc("glXQueryVersion", "custom"),
+    _glxFunc("glXImportContextEXT", "custom", public=False),
+    _glxFunc("glXFreeContextEXT", "custom", public=False),
+
+)
+

--- a/src/GLX/libglxmapping.h
+++ b/src/GLX/libglxmapping.h
@@ -91,12 +91,6 @@ typedef struct __GLXlocalDispatchFunctionRec {
 } __GLXlocalDispatchFunction;
 
 /*!
- * A NULL-termianted list of GLX dispatch functions that are implemented in
- * libGLX instead of in any vendor library.
- */
-extern const __GLXlocalDispatchFunction LOCAL_GLX_DISPATCH_FUNCTIONS[];
-
-/*!
  * Accessor functions used to retrieve the "current" dispatch table for each of
  * the three types of dispatch tables (see libglxabi.h for an explanation of
  * these types).

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,5 @@
 SUBDIRS = util \
+	vendor \
 	GLdispatch \
 	GLX \
 	OpenGL \

--- a/src/vendor/Makefile.am
+++ b/src/vendor/Makefile.am
@@ -1,0 +1,60 @@
+# Copyright (c) 2016, NVIDIA CORPORATION.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and/or associated documentation files (the
+# "Materials"), to deal in the Materials without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Materials, and to
+# permit persons to whom the Materials are furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# unaltered in all copies or substantial portions of the Materials.
+# Any additions, deletions, or changes to the original source files
+# must be clearly indicated in accompanying documentation.
+#
+# If only executable code is distributed, then the accompanying
+# documentation must state that "this software is based in part on the
+# work of the Khronos Group."
+#
+# THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+noinst_HEADERS = glxdispatchstubs.h
+
+EXTRA_DIST = example_glx_function_list.py gen_glx_dispatch.py
+
+BUILT_SOURCES = g_glxdispatchstubs.h g_glxdispatchstubs.c
+
+CLEANFILES = $(BUILT_SOURCES)
+
+GEN_DISPATCH_SCRIPT = $(top_srcdir)/src/vendor/gen_glx_dispatch.py
+DISPATCH_FUNC_LIST = $(top_srcdir)/src/GLX/libglx_function_list.py
+DISPATCH_XML_FILES = $(top_srcdir)/src/generate/xml/glx.xml
+GEN_DISPATCH_DEPS = \
+	$(GEN_DISPATCH_SCRIPT) \
+	$(DISPATCH_FUNC_LIST) \
+	$(DISPATCH_XML_FILES) \
+	$(top_srcdir)/src/generate/genCommon.py
+
+g_glxdispatchstubs.h : $(GEN_DISPATCH_DEPS)
+	$(AM_V_GEN) PYTHONPATH=$(top_srcdir)/src/generate $(PYTHON2) \
+		$(GEN_DISPATCH_SCRIPT) header $(DISPATCH_FUNC_LIST) \
+		$(DISPATCH_XML_FILES) > $@
+
+g_glxdispatchstubs.c : $(GEN_DISPATCH_DEPS)
+	$(AM_V_GEN) PYTHONPATH=$(top_srcdir)/src/generate $(PYTHON2) \
+		$(GEN_DISPATCH_SCRIPT) source $(DISPATCH_FUNC_LIST) \
+		$(DISPATCH_XML_FILES) > $@
+
+noinst_LTLIBRARIES = libglxdispatchstubs.la
+libglxdispatchstubs_la_CFLAGS = -I$(top_srcdir)/include
+libglxdispatchstubs_la_SOURCES = \
+	glxdispatchstubs.c \
+	g_glxdispatchstubs.c
+

--- a/src/vendor/example_glx_function_list.py
+++ b/src/vendor/example_glx_function_list.py
@@ -1,0 +1,232 @@
+#!/usr/bin/python
+
+# Copyright (c) 2016, NVIDIA CORPORATION.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and/or associated documentation files (the
+# "Materials"), to deal in the Materials without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Materials, and to
+# permit persons to whom the Materials are furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# unaltered in all copies or substantial portions of the Materials.
+# Any additions, deletions, or changes to the original source files
+# must be clearly indicated in accompanying documentation.
+#
+# If only executable code is distributed, then the accompanying
+# documentation must state that "this software is based in part on the
+# work of the Khronos Group."
+#
+# THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+"""
+The GLX function list, used by gen_glx_dispatch.py.
+
+GLX Function values:
+- "method"
+    How to select a vendor library. See "Method values" below.
+
+- "add_mapping"
+    Specifies that the return value should be added to one of libGLX's
+    mappings. See "add_mapping values" below.
+
+- "remove_mapping"
+    Specifies that the return value should be removed to one of libGLX's
+    mappings.
+
+    Allowed values are "context", "drawable", and "config".
+
+- "remove_key"
+    The parameter that contains the value to remove from libGLX's mapping.
+    If unspecified, the default is the same as the "key" field.
+
+- "prefix"
+    If True, the function should be exported from the library. This is used for
+    generating dispatch stubs for libGLX itself -- vendor libraries generally
+    should not use it.
+
+- "static"
+    If this is True, then the function will be declared static.
+
+- "public"
+    If True, the function should be exported from the library. Vendor libraries
+    generally should not use this.
+
+- "display"
+    The name of the parameter that contains the Display pointer.
+    May be "<current>" to specify the current display.
+    If not specified, it will look for a parameter with the correct type.
+
+- "extension"
+    The name of an extension macro to check for before defining the function.
+
+- "inheader"
+    If True, then this function should be declared in the generated header
+    file.
+
+method values:
+- "custom"
+    The dispatch stub will be hand-written instead of generated.
+
+- "none"
+    No dispatch function exists at all, but the function should still have an
+    entry in the index array. This is for other functions that a stub may need
+    to call that are implemented in libGLX itself.
+
+- "current"
+    Use the current context.
+
+- "drawable", "context", "config"
+    Look up by a GLXDrawable, GLXContext, or GLXFBConfig parameter.
+    The parameter is given by the "key" field. If unspecified, it will use the
+    first parameter of the correct type that it finds.
+
+- "screen"
+    Get a screen number from a parameter.
+    The parameter name is given by the "key" field. If unspecifid, the default
+    parameter name is "screen".
+
+- "xvisinfo"
+    Use an XVisualInfo pointer from a parameter.
+    The parameter name is given by the "key" field. If unspecifid, it will look
+    for the first XVisualInfo parameter.
+
+add_mapping values:
+- "context", "drawable", "config"
+    Adds the returned GLXContext, GLXDrawable, or GLXConfig.
+
+- "config_list"
+    Adds an array of GLXFBConfig values. In this case, you also need to specify
+    a pointer to the item count in the "nelements" field.
+"""
+
+def _glxFunc(name, method, opcode=None, error=None, prefix="dispatch_",
+        display=None, key=None, extension=None, retval=None, static=None,
+        public=False, inheader=None, add_mapping=None, nelements=None,
+        remove_mapping=None, remove_key=None):
+
+    if (static == None):
+        static = (method not in ("none", "custom"))
+    if (inheader == None):
+        inheader = (method != "none" and not static)
+    values = {
+        "method" : method,
+        "opcode" : opcode,
+        "error" : error,
+        "key" : key,
+        "prefix" : prefix,
+        "display" : display,
+        "extension" : extension,
+        "retval" : retval,
+        "static" : static,
+        "public" : public,
+        "inheader" : inheader,
+        "add_mapping" : add_mapping,
+        "nelements" : nelements,
+        "remove_mapping" : remove_mapping,
+        "remove_key" : remove_key,
+    }
+    return (name, values)
+
+GLX_FUNCTIONS = (
+    # GLX core functions. These are all implemented in libGLX, but are listed
+    # here to keep track of the dispatch indexes for them.
+    _glxFunc("glXChooseFBConfig", "none"),
+    _glxFunc("glXCreateContext", "none"),
+    _glxFunc("glXCreateGLXPixmap", "none"),
+    _glxFunc("glXCreateNewContext", "none"),
+    _glxFunc("glXCreatePbuffer", "none"),
+    _glxFunc("glXCreatePixmap", "none"),
+    _glxFunc("glXCreateWindow", "none"),
+    _glxFunc("glXDestroyGLXPixmap", "none"),
+    _glxFunc("glXDestroyPbuffer", "none"),
+    _glxFunc("glXDestroyPixmap", "none"),
+    _glxFunc("glXDestroyWindow", "none"),
+    _glxFunc("glXGetConfig", "none"),
+    _glxFunc("glXChooseVisual", "none"),
+    _glxFunc("glXCopyContext", "none"),
+    _glxFunc("glXGetFBConfigAttrib", "none"),
+    _glxFunc("glXGetFBConfigs", "none"),
+    _glxFunc("glXGetSelectedEvent", "none"),
+    _glxFunc("glXGetVisualFromFBConfig", "none"),
+    _glxFunc("glXIsDirect", "none"),
+    _glxFunc("glXQueryExtensionsString", "none"),
+    _glxFunc("glXQueryServerString", "none"),
+    _glxFunc("glXQueryContext", "none"),
+    _glxFunc("glXQueryDrawable", "none"),
+    _glxFunc("glXSelectEvent", "none"),
+    _glxFunc("glXSwapBuffers", "none"),
+    _glxFunc("glXUseXFont", "none"),
+    _glxFunc("glXWaitGL", "none"),
+    _glxFunc("glXWaitX", "none"),
+    _glxFunc("glXDestroyContext", "none"),
+    _glxFunc("glXGetClientString", "none"),
+    _glxFunc("glXGetCurrentContext", "none"),
+    _glxFunc("glXGetCurrentDisplay", "none"),
+    _glxFunc("glXGetCurrentDrawable", "none"),
+    _glxFunc("glXGetCurrentReadDrawable", "none"),
+    _glxFunc("glXGetProcAddress", "none"),
+    _glxFunc("glXGetProcAddressARB", "none"),
+    _glxFunc("glXMakeContextCurrent", "none"),
+    _glxFunc("glXMakeCurrent", "none"),
+    _glxFunc("glXQueryExtension", "none"),
+    _glxFunc("glXQueryVersion", "none"),
+
+    # GLX_ARB_create_context
+    _glxFunc("glXCreateContextAttribsARB", "config", "X_GLXCreateContextAtrribsARB", add_mapping="context"),
+
+    # GLX_EXT_import_context
+    _glxFunc("glXImportContextEXT", "none"), # Implemented in libGLX
+    _glxFunc("glXFreeContextEXT", "none"), # Implemented in libGLX
+    _glxFunc("glXGetContextIDEXT", "context", None),
+    _glxFunc("glXGetCurrentDisplayEXT", "current"),
+    _glxFunc("glXQueryContextInfoEXT", "context", "X_GLXVendorPrivateWithReply"),
+
+    # GLX_EXT_texture_from_pixmap
+    _glxFunc("glXBindTexImageEXT", "drawable", "X_GLXVendorPrivate", error="GLXBadPixmap"),
+    _glxFunc("glXReleaseTexImageEXT", "drawable", "X_GLXVendorPrivate", error="GLXBadPixmap"),
+
+    # GLX_EXT_swap_control
+    _glxFunc("glXSwapIntervalEXT", "drawable", "X_GLXVendorPrivate", error="GLXBadDrawable"),
+
+    # GLX_SGI_video_sync
+    _glxFunc("glXGetVideoSyncSGI", "current"),
+    _glxFunc("glXWaitVideoSyncSGI", "current"),
+
+    # GLX_SGI_swap_control
+    _glxFunc("glXSwapIntervalSGI", "current"),
+
+    # GLX_SGIX_swap_barrier
+    _glxFunc("glXBindSwapBarrierSGIX", "drawable"),
+    _glxFunc("glXQueryMaxSwapBarriersSGIX", "screen"),
+
+    # GLX_SGIX_video_resize
+    _glxFunc("glXBindChannelToWindowSGIX", "screen"),
+    _glxFunc("glXChannelRectSGIX", "screen"),
+    _glxFunc("glXQueryChannelRectSGIX", "screen"),
+    _glxFunc("glXQueryChannelDeltasSGIX", "screen"),
+    _glxFunc("glXChannelRectSyncSGIX", "screen"),
+
+    # GLX_SGIX_fbconfig
+    _glxFunc("glXCreateContextWithConfigSGIX", "config", "X_GLXVendorPrivateWithReply", add_mapping="context"),
+    _glxFunc("glXGetFBConfigAttribSGIX", "config", "X_GLXVendorPrivateWithReply"),
+    _glxFunc("glXChooseFBConfigSGIX", "screen", add_mapping="config_list", nelements=3),
+    _glxFunc("glXCreateGLXPixmapWithConfigSGIX", "config", "X_GLXVendorPrivateWithReply", add_mapping="drawable"),
+    _glxFunc("glXGetVisualFromFBConfigSGIX", "config", "X_GLXVendorPrivateWithReply"),
+    _glxFunc("glXGetFBConfigFromVisualSGIX", "xvisinfo"),
+
+    # GLX_SGIX_pbuffer
+    _glxFunc("glXCreateGLXPbufferSGIX", "config", "X_GLXVendorPrivateWithReply", add_mapping="drawable"),
+    _glxFunc("glXDestroyGLXPbufferSGIX", "drawable", "X_GLXVendorPrivateWithReply", remove_mapping="drawable"),
+    _glxFunc("glXQueryGLXPbufferSGIX", "drawable", "X_GLXVendorPrivateWithReply"),
+    _glxFunc("glXSelectEventSGIX", "drawable", "X_GLXVendorPrivateWithReply"),
+    _glxFunc("glXGetSelectedEventSGIX", "drawable", "X_GLXVendorPrivateWithReply"),
+)

--- a/src/vendor/gen_glx_dispatch.py
+++ b/src/vendor/gen_glx_dispatch.py
@@ -1,0 +1,407 @@
+#!/usr/bin/python
+
+# Copyright (c) 2016, NVIDIA CORPORATION.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and/or associated documentation files (the
+# "Materials"), to deal in the Materials without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Materials, and to
+# permit persons to whom the Materials are furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# unaltered in all copies or substantial portions of the Materials.
+# Any additions, deletions, or changes to the original source files
+# must be clearly indicated in accompanying documentation.
+#
+# If only executable code is distributed, then the accompanying
+# documentation must state that "this software is based in part on the
+# work of the Khronos Group."
+#
+# THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+"""
+Generates dispatch functions for GLX.
+
+This script is provided to make it easier to generate the GLX dispatch stubs
+for a vendor library.
+
+The script will read a list of functions from Khronos's glx.xml list, with
+additional information provided in a separate Python module.
+
+See example_glx_function_list.py for an example of the function list.
+"""
+
+import sys
+import collections
+import imp
+
+import os.path
+import genCommon
+
+_GLX_DRAWABLE_TYPES = frozenset(("GLXDrawable", "GLXWindow", "GLXPixmap",
+        "GLXPbuffer", "GLXPbufferSGIX"))
+_GLX_FBCONFIG_TYPES = frozenset(("GLXFBConfig", "GLXFBConfigSGIX"))
+
+def main():
+    if (len(sys.argv) < 4):
+        print("Usage: %r source|header <function_list> <xml_file> [xml_file...]" % (sys.argv[0],))
+        sys.exit(2)
+
+    target = sys.argv[1]
+    funcListFile = sys.argv[2]
+    xmlFiles = sys.argv[3:]
+
+    # The function list is a Python module, but it's specified on the command
+    # line.
+    glxFunctionList = imp.load_source("glxFunctionList", funcListFile)
+
+    xmlFunctions = genCommon.getFunctions(xmlFiles)
+    xmlByName = dict((f.name, f) for f in xmlFunctions)
+    functions = []
+    for (name, glxFunc) in glxFunctionList.GLX_FUNCTIONS:
+        func = xmlByName[name]
+        glxFunc = fixupFunc(func, glxFunc)
+        functions.append((func, glxFunc))
+
+    # Sort the function list by name.
+    functions = sorted(functions, key=lambda f: f[0].name)
+
+    if (target == "header"):
+        text = generateHeader(functions)
+    elif (target == "source"):
+        text = generateSource(functions)
+    else:
+        raise ValueError("Invalid target: %r" % (target,))
+    sys.stdout.write(text)
+
+def fixupFunc(func, glxFunc):
+    """
+    Does some basic error-checking on a function, and fills in default values
+    for any fields that haven't been set.
+    """
+
+    result = dict(glxFunc)
+    if (result.get("prefix") == None):
+        result["prefix"] = ""
+
+    if (result.get("static") == None):
+        result["static"] = False
+
+    if (result.get("public") == None):
+        result["public"] = False
+
+    if (result.get("static") and result.get("public")):
+        raise ValueError("Function %s cannot be both static and public" % (func.name,))
+
+    # If the method is "custom" or "none", then we're not going to generate a
+    # stub for it, so the rest of the data doesn't matter.
+    if (result["method"] in ("custom", "none")):
+        return result
+
+    if (func.hasReturn()):
+        if (result.get("retval") == None):
+            result["retval"] = getDefaultReturnValue(func.rt)
+
+    if (result.get("extension") != None):
+        text = "defined(" + result["extension"] + ")"
+        result["extension"] = text
+
+    if (result["method"] != "current"):
+        # This function is dispatched based on a paramter. Figure out which
+        # one.
+        if (result.get("key") != None):
+            # The parameter was specified, so just use it.
+            result["key"] = fixupParamName(func, result["key"])
+        else:
+            # Look for a parameter of the correct type.
+            if (result["method"] == "drawable"):
+                result["key"] = findParamByType(func, _GLX_DRAWABLE_TYPES)
+            elif (result["method"] == "context"):
+                result["key"] = findParamByType(func, ("GLXContext", "const GLXContext"))
+            elif (result["method"] == "config"):
+                result["key"] = findParamByType(func, _GLX_FBCONFIG_TYPES)
+            elif (result["method"] == "screen"):
+                result["key"] = fixupParamName(func, "screen")
+            elif (result["method"] == "xvisinfo"):
+                result["key"] = findParamByType(func, ("XVisualInfo *", "const XVisualInfo *"))
+            else:
+                raise ValueError("Unknown lookup method %r for function %r" % (result["method"], func.name))
+            if (result["key"] == None):
+                raise ValueError("Can't find lookup key for function %r" % (func.name,))
+
+        if (result["method"] == "xvisinfo"):
+            # If we're using an XVisualInfo pointer, then we just need the
+            # screen number from it.
+            result["key"] = "(" + result["key"] + ")->screen"
+            result["method"] = "screen"
+
+    if (result["method"] == "drawable"):
+        # For reporting errors when we look up a vendor by drawable, we also
+        # have to specify the error code.
+        if (result.get("opcode") != None and result.get("error") == None):
+            raise ValueError("Missing error code for function %r" % (func.name,))
+
+    if (result.get("remove_mapping") != None):
+        if (result["remove_mapping"] not in ("context", "drawable", "config")):
+            raise ValueError("Invalid remove_mapping value %r for function %r" %
+                    (result["remove_mapping"], func.name))
+        if (result.get("remove_key") != None):
+            result["remove_key"] = fixupParamName(func, result["remove_key"])
+        else:
+            assert(result["remove_mapping"] == result["method"])
+            result["remove_key"] = result["key"]
+
+    if (result.get("opcode") == None):
+        result["opcode"] = "-1"
+        result["error"] = "-1"
+
+    if (result.get("display") != None):
+        result["display"] = fixupParamName(func, result["display"])
+    else:
+        result["display"] = findParamByType(func, ("Display *",))
+        if (result["display"] == None):
+            if (getNeedsDisplayPointer(func, result)):
+                raise ValueError("Can't find display pointer for function %r" % (func.name,))
+            result["display"] = "NULL"
+
+    return result
+
+def getDefaultReturnValue(typename):
+    """
+    Picks a default return value. The dispatch stub will return this value if
+    it can't find an implementation function.
+    """
+    if (typename.endswith("*")):
+        return "NULL"
+    if (typename == "GLXContext" or typename in _GLX_FBCONFIG_TYPES):
+        return "NULL"
+    if (typename in _GLX_DRAWABLE_TYPES):
+        return "None"
+    if (typename in ("XID", "GLXFBConfigID", "GLXContextID")):
+        return "None"
+
+    return "0"
+
+def getNeedsDisplayPointer(func, glxFunc):
+    """
+    Returns True if a function needs a Display pointer.
+    """
+    if (glxFunc["method"] not in ("none", "custom", "context", "current")):
+        return True
+    if (glxFunc.get("add_mapping") != None):
+        return True
+    if (glxFunc.get("remove_mapping") != None):
+        return True
+    return False
+
+def findParamByType(func, typeNames):
+    """
+    Looks for a parameter of a given data type. Returns the name of the
+    parameter, or None if no matching parameter was found.
+    """
+    for arg in func.args:
+        if (arg.type in typeNames):
+            return arg.name
+    return None
+
+def fixupParamName(func, paramSpec):
+    """
+    Takes a parameter that was specified in the function list and returns a
+    parameter name or a C expression.
+    """
+    try:
+        # If the parameter is an integer, then treat it as a parameter index.
+        index = int(paramSpec)
+        return func.args[index]
+    except ValueError:
+        # Not an integer
+        pass
+
+    # If the string is contained in parentheses, then assume it's a valid C
+    # expression.
+    if (paramSpec.startswith("(") and paramSpec.endswith(")")):
+        return paramSpec[1:-1]
+
+    # Otherwise, assume the string is a parameter name.
+    for arg in func.args:
+        if (arg.name == paramSpec):
+            return arg.name
+
+    raise ValueError("Invalid parameter name %r in function %r" % (paramSpec, func))
+
+def generateHeader(functions):
+    text = r"""
+#ifndef G_GLXDISPATCH_STUBS_H
+#define G_GLXDISPATCH_STUBS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <GL/gl.h>
+#include <GL/glx.h>
+#include <GL/glxext.h>
+
+""".lstrip("\n")
+
+    text += "enum {\n"
+    for (func, glxFunc) in functions:
+        text += generateGuardBegin(func, glxFunc)
+        text += "    __GLX_DISPATCH_" + func.name + ",\n"
+        text += generateGuardEnd(func, glxFunc)
+    text += "    __GLX_DISPATCH_COUNT\n"
+    text += "};\n\n"
+
+    for (func, glxFunc) in functions:
+        if (glxFunc["inheader"]):
+            text += generateGuardBegin(func, glxFunc)
+            text += "{f.rt} {ex[prefix]}{f.name}({f.decArgs});\n".format(f=func, ex=glxFunc)
+            text += generateGuardEnd(func, glxFunc)
+
+    text += r"""
+#ifdef __cplusplus
+}
+#endif
+#endif // G_GLXDISPATCH_STUBS_H
+"""
+    return text
+
+def generateSource(functions):
+    text = r'''
+#include "glxdispatchstubs.h"
+#include "g_glxdispatchstubs.h"
+
+#include <X11/Xlibint.h>
+#include <GL/glxproto.h>
+
+'''.lstrip("\n")
+
+    for (func, glxFunc) in functions:
+        if (glxFunc["method"] not in ("none", "custom")):
+            text += generateGuardBegin(func, glxFunc)
+            text += generateDispatchFunc(func, glxFunc)
+            text += generateGuardEnd(func, glxFunc)
+
+    text += "\n"
+    text += "const char * const __GLX_DISPATCH_FUNC_NAMES[__GLX_DISPATCH_COUNT] = {\n"
+    for (func, glxFunc) in functions:
+        text += generateGuardBegin(func, glxFunc)
+        text += '    "' + func.name + '",\n'
+        text += generateGuardEnd(func, glxFunc)
+    text += "};\n"
+
+    text += "const __GLXextFuncPtr __GLX_DISPATCH_FUNCS[__GLX_DISPATCH_COUNT] = {\n"
+    for (func, glxFunc) in functions:
+        text += generateGuardBegin(func, glxFunc)
+        if (glxFunc["method"] != "none"):
+            text += "    (__GLXextFuncPtr) " + glxFunc["prefix"] + func.name + ",\n"
+        else:
+            text += "    NULL, // " + func.name + "\n"
+        text += generateGuardEnd(func, glxFunc)
+    text += "};\n"
+
+    return text
+
+def generateGuardBegin(func, glxFunc):
+    ext = glxFunc.get("extension")
+    if (ext != None):
+        return "#if " + ext + "\n"
+    else:
+        return ""
+
+def generateGuardEnd(func, glxFunc):
+    if (glxFunc.get("extension") != None):
+        return "#endif\n"
+    else:
+        return ""
+
+def generateDispatchFunc(func, glxFunc):
+    text = ""
+
+    if (glxFunc["static"]):
+        text += "static "
+    elif (glxFunc["public"]):
+        text += "PUBLIC "
+
+    text += r"""{f.rt} {ex[prefix]}{f.name}({f.decArgs})
+{{
+    typedef {f.rt} (* _pfn_{f.name})({f.decArgs});
+"""
+
+    text += "    __GLXvendorInfo *_vendor;\n"
+    text += "    _pfn_{f.name} _ptr_{f.name};\n"
+    if (func.hasReturn()):
+        text += "    {f.rt} _ret = {ex[retval]};\n"
+    text += "\n"
+
+    # Look up the vendor library
+    text += "    _vendor = "
+    if (glxFunc["method"] == "current"):
+        text += "__glXDispatchApiExports->getCurrentDynDispatch();\n"
+    elif (glxFunc["method"] == "screen"):
+        text += "__glXDispatchApiExports->getDynDispatch({ex[display]}, {ex[key]});\n"
+    elif (glxFunc["method"] == "drawable"):
+        text += "__glxDispatchVendorByDrawable({ex[display]}, {ex[key]}, {ex[opcode]}, {ex[error]});\n"
+    elif (glxFunc["method"] == "context"):
+        text += "__glxDispatchVendorByContext({ex[display]}, {ex[key]}, {ex[opcode]});\n"
+    elif (glxFunc["method"] == "config"):
+        text += "__glxDispatchVendorByConfig({ex[display]}, {ex[key]}, {ex[opcode]});\n"
+    else:
+        raise ValueError("Unknown dispatch method: %r" % (glxFunc["method"],))
+
+    # Look up and call the function.
+    text += r"""
+    if (_vendor != NULL) {{
+        _ptr_{f.name} = (_pfn_{f.name})
+            __glXDispatchApiExports->fetchDispatchEntry(_vendor, __glXDispatchFuncIndices[__GLX_DISPATCH_{f.name}]);
+        if (_ptr_{f.name} != NULL) {{
+""".lstrip("\n")
+
+    text += "            "
+    if (func.hasReturn()):
+        text += "_ret = "
+    text += "(*_ptr_{f.name})({f.callArgs});\n"
+
+    # Handle any added or removed object mappings.
+    if (glxFunc.get("add_mapping") != None):
+        if (glxFunc["add_mapping"] == "context"):
+            text += "            _ret = __glXDispatchAddContextMapping({ex[display]}, _ret, _vendor);\n"
+        elif (glxFunc["add_mapping"] == "drawable"):
+            text += "            __glXDispatchAddDrawableMapping({ex[display]}, _ret, _vendor);\n"
+        elif (glxFunc["add_mapping"] == "config"):
+            text += "            _ret = __glXDispatchAddFBConfigMapping({ex[display]}, _ret, _vendor);\n"
+        elif (glxFunc["add_mapping"] == "config_list"):
+            text += "            _ret = __glXDispatchAddFBConfigListMapping({ex[display]}, _ret, nelements, _vendor);\n"
+        else:
+            raise ValueError("Unknown add_mapping method: %r" % (glxFunc["add_mapping"],))
+
+    if (glxFunc.get("remove_mapping") != None):
+        if (glxFunc["remove_mapping"] == "context"):
+            text += "            __glXDispatchApiExports->removeVendorContextMapping({ex[display]}, {ex[remove_key]});\n"
+        elif (glxFunc["remove_mapping"] == "drawable"):
+            text += "            __glXDispatchApiExports->removeVendorDrawableMapping({ex[display]}, {ex[remove_key]});\n"
+        elif (glxFunc["remove_mapping"] == "config"):
+            text += "            __glXDispatchApiExports->removeVendorFBConfigMapping({ex[display]}, {ex[remove_key]});\n"
+        else:
+            raise ValueError("Unknown remove_mapping method: %r" % (glxFunc["add_mapping"],))
+
+    text += "        }}\n"
+    text += "    }}\n"
+    if (func.hasReturn()):
+        text += "    return _ret;\n"
+    text += "}}\n\n"
+
+    text = text.format(f=func, ex=glxFunc)
+    return text
+
+if (__name__ == "__main__"):
+    main()
+

--- a/src/vendor/gen_glx_dispatch.py
+++ b/src/vendor/gen_glx_dispatch.py
@@ -291,14 +291,15 @@ def generateSource(functions):
             text += generateGuardEnd(func, glxFunc)
 
     text += "\n"
-    text += "const char * const __GLX_DISPATCH_FUNC_NAMES[__GLX_DISPATCH_COUNT] = {\n"
+    text += "const char * const __GLX_DISPATCH_FUNC_NAMES[__GLX_DISPATCH_COUNT + 1] = {\n"
     for (func, glxFunc) in functions:
         text += generateGuardBegin(func, glxFunc)
         text += '    "' + func.name + '",\n'
         text += generateGuardEnd(func, glxFunc)
+    text += "    NULL,\n"
     text += "};\n"
 
-    text += "const __GLXextFuncPtr __GLX_DISPATCH_FUNCS[__GLX_DISPATCH_COUNT] = {\n"
+    text += "const __GLXextFuncPtr __GLX_DISPATCH_FUNCS[__GLX_DISPATCH_COUNT + 1] = {\n"
     for (func, glxFunc) in functions:
         text += generateGuardBegin(func, glxFunc)
         if (glxFunc["method"] != "none"):
@@ -306,6 +307,7 @@ def generateSource(functions):
         else:
             text += "    NULL, // " + func.name + "\n"
         text += generateGuardEnd(func, glxFunc)
+    text += "    NULL,\n"
     text += "};\n"
 
     return text

--- a/src/vendor/glxdispatchstubs.c
+++ b/src/vendor/glxdispatchstubs.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2016, NVIDIA CORPORATION.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and/or associated documentation files (the
+ * "Materials"), to deal in the Materials without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Materials, and to
+ * permit persons to whom the Materials are furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * unaltered in all copies or substantial portions of the Materials.
+ * Any additions, deletions, or changes to the original source files
+ * must be clearly indicated in accompanying documentation.
+ *
+ * If only executable code is distributed, then the accompanying
+ * documentation must state that "this software is based in part on the
+ * work of the Khronos Group."
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+ */
+
+#include "glxdispatchstubs.h"
+
+#include <X11/Xlibint.h>
+#include <GL/glxproto.h>
+#include <string.h>
+
+#include "g_glxdispatchstubs.h"
+
+const __GLXapiExports *__glXDispatchApiExports = NULL;
+int __glXDispatchFuncIndices[__GLX_DISPATCH_COUNT];
+const int __GLX_DISPATCH_FUNCTION_COUNT = __GLX_DISPATCH_COUNT;
+
+static int FindProcIndex(const GLubyte *name)
+{
+    int i;
+    for (i=0; i<__GLX_DISPATCH_COUNT; i++) {
+        if (strcmp(__GLX_DISPATCH_FUNC_NAMES[i], (const char *) name) == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+void __glxInitDispatchStubs(const __GLXapiExports *exportsTable)
+{
+    int i;
+    __glXDispatchApiExports = exportsTable;
+    for (i=0; i<__GLX_DISPATCH_COUNT; i++) {
+        __glXDispatchFuncIndices[i] = -1;
+    }
+}
+
+void __glxSetDispatchIndex(const GLubyte *name, int dispatchIndex)
+{
+    int index = FindProcIndex(name);
+    if (index >= 0) {
+        __glXDispatchFuncIndices[index] = dispatchIndex;
+    }
+}
+
+void *__glxDispatchFindDispatchFunction(const GLubyte *name)
+{
+    int index = FindProcIndex(name);
+    if (index >= 0) {
+        return __GLX_DISPATCH_FUNCS[index];
+    } else {
+        return NULL;
+    }
+}
+
+__GLXvendorInfo *__glxDispatchVendorByDrawable(Display *dpy, GLXDrawable draw,
+        int opcode, int error)
+{
+    __GLXvendorInfo *vendor = NULL;
+
+    if (draw != None) {
+        vendor = __glXDispatchApiExports->vendorFromDrawable(dpy, draw);
+    }
+    if (vendor == NULL && dpy != NULL && opcode >= 0 && error >= 0) {
+        __glXSendError(dpy, error, draw, opcode, False);
+    }
+    return vendor;
+}
+
+__GLXvendorInfo *__glxDispatchVendorByContext(Display *dpy, GLXContext context,
+        int opcode)
+{
+    __GLXvendorInfo *vendor = NULL;
+
+    if (context != NULL) {
+        vendor = __glXDispatchApiExports->vendorFromContext(context);
+    }
+    if (vendor == NULL && dpy != NULL && opcode >= 0) {
+        __glXSendError(dpy, GLXBadContext, 0, opcode, False);
+    }
+    return vendor;
+}
+
+__GLXvendorInfo *__glxDispatchVendorByConfig(Display *dpy, GLXFBConfig config,
+        int opcode)
+{
+    __GLXvendorInfo *vendor = NULL;
+
+    if (config != NULL) {
+        vendor = __glXDispatchApiExports->vendorFromFBConfig(dpy, config);
+    }
+    if (vendor == NULL && dpy != NULL && opcode >= 0) {
+        __glXSendError(dpy, GLXBadFBConfig, 0, opcode, False);
+    }
+    return vendor;
+}
+
+
+GLXContext __glXDispatchAddContextMapping(Display *dpy, GLXContext context, __GLXvendorInfo *vendor)
+{
+    if (context != NULL) {
+        if (__glXDispatchApiExports->addVendorContextMapping(dpy, context, vendor) != 0) {
+            // We couldn't add the new context to libGLX's mapping. Call into
+            // the vendor to destroy the context again before returning.
+            typedef void (* pfn_glXDestroyContext) (Display *dpy, GLXContext ctx);
+            pfn_glXDestroyContext ptr_glXDestroyContext = (pfn_glXDestroyContext)
+                __glXDispatchApiExports->fetchDispatchEntry(vendor,
+                        __glXDispatchFuncIndices[__GLX_DISPATCH_glXDestroyContext]);
+            if (ptr_glXDestroyContext != NULL) {
+                ptr_glXDestroyContext(dpy, context);
+            }
+            context = NULL;
+        }
+    }
+    return context;
+}
+
+void __glXDispatchAddDrawableMapping(Display *dpy, GLXDrawable draw, __GLXvendorInfo *vendor)
+{
+    if (draw != None) {
+        // We don't have to worry about failing to add a mapping in this case,
+        // because libGLX can look up the vendor for the drawable on its own.
+        __glXDispatchApiExports->addVendorDrawableMapping(dpy, draw, vendor);
+    }
+}
+
+GLXFBConfig __glXDispatchAddFBConfigMapping(Display *dpy, GLXFBConfig config, __GLXvendorInfo *vendor)
+{
+    if (config != NULL) {
+        if (__glXDispatchApiExports->addVendorFBConfigMapping(dpy, config, vendor) != 0) {
+            config = NULL;
+        }
+    }
+    return config;
+}
+
+GLXFBConfig *__glXDispatchAddFBConfigListMapping(Display *dpy, GLXFBConfig *configs, int *nelements, __GLXvendorInfo *vendor)
+{
+    if (configs != NULL && nelements != NULL) {
+        int i;
+        Bool success = True;
+        for (i=0; i<*nelements; i++) {
+            if (__glXDispatchApiExports->addVendorFBConfigMapping(dpy, configs[i], vendor) != 0) {
+                success = False;
+                break;
+            }
+        }
+        if (!success) {
+            XFree(configs);
+            configs = NULL;
+            *nelements = 0;
+        }
+    }
+    return configs;
+}
+

--- a/src/vendor/glxdispatchstubs.h
+++ b/src/vendor/glxdispatchstubs.h
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2016, NVIDIA CORPORATION.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and/or associated documentation files (the
+ * "Materials"), to deal in the Materials without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Materials, and to
+ * permit persons to whom the Materials are furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * unaltered in all copies or substantial portions of the Materials.
+ * Any additions, deletions, or changes to the original source files
+ * must be clearly indicated in accompanying documentation.
+ *
+ * If only executable code is distributed, then the accompanying
+ * documentation must state that "this software is based in part on the
+ * work of the Khronos Group."
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+ */
+
+#ifndef GLXDISPATCHSTUBS_H
+#define GLXDISPATCHSTUBS_H
+
+/*!
+ * \file
+ *
+ * Functions for GLX dispatch stubs.
+ *
+ * This file declares various helper functions used with the GLX dispatch stubs.
+ */
+
+#include "glvnd/libglxabi.h"
+
+#include "compiler.h" // Only needed for the PUBLIC macro
+
+/*!
+ * An array containing the names of all known GLX functions.
+ */
+extern const char * const __GLX_DISPATCH_FUNC_NAMES[];
+
+/*!
+ * An array containing the dispatch stubs for GLX functions. Note that some
+ * elements may be NULL if no dispatch function is defined. This is used for
+ * functions like glXDestroyContext, where we'll need an index so that we can
+ * look up the function from other dispatch stubs.
+ */
+extern const __GLXextFuncPtr __GLX_DISPATCH_FUNCS[];
+
+/*!
+ * The dispatch index for each function.
+ */
+extern int __glXDispatchFuncIndices[];
+
+/*!
+ * The number of GLX functions. This is the length of the
+ * \c __GLX_DISPATCH_FUNC_NAMES, \c __GLX_DISPATCH_FUNCS, and
+ * \c __glXDispatchFuncIndices arrays.
+ */
+extern const int __GLX_DISPATCH_FUNCTION_COUNT;
+
+/*!
+ * A pointer to the exports table from libGLX.
+ */
+extern const __GLXapiExports *__glXDispatchApiExports;
+
+/*!
+ * Initializes the dispatch functions.
+ *
+ * This will set the __GLXapiExports pointer for the stubs to use and will
+ * initialize the index array.
+ */
+void __glxInitDispatchStubs(const __GLXapiExports *exportsTable);
+
+/*!
+ * Sets the dispatch index for a function.
+ *
+ * This function can be used for the vendor's \c __GLXapiImports::setDispatchIndex
+ * callback.
+ */
+void __glxSetDispatchIndex(const GLubyte *name, int index);
+
+/*!
+ * Returns the dispatch function for the given name, or \c NULL if the function
+ * isn't supported.
+ *
+ * This function can be used for the vendor's \c __GLXapiImports::getDispatchAddress
+ * callback.
+ */
+void *__glxDispatchFindDispatchFunction(const GLubyte *name);
+
+/*!
+ * Reports an X error. This function must be defined by the vendor library.
+ */
+void __glXSendError(Display *dpy, unsigned char errorCode,
+        XID resourceID, unsigned char minorCode, Bool coreX11error);
+
+// Helper functions used by the generated stubs.
+
+/*!
+ * Looks up a vendor from a drawable.
+ *
+ * If \p opcode and \p error are non-negative, then they are used to report an
+ * X error if the lookup fails.
+ */
+__GLXvendorInfo *__glxDispatchVendorByDrawable(Display *dpy, GLXDrawable draw,
+        int opcode, int error);
+
+/*!
+ * Looks up a vendor from a context.
+ */
+__GLXvendorInfo *__glxDispatchVendorByContext(Display *dpy, GLXContext ctx,
+        int opcode);
+
+/*!
+ * Looks up a vendor from a GLXFBConfig.
+ */
+__GLXvendorInfo *__glxDispatchVendorByConfig(Display *dpy, GLXFBConfig config,
+        int opcode);
+
+/*!
+ * Adds a GLXContext to libGLX's mapping.
+ *
+ * If it fails to add the context to the map, then this function will try to
+ * destroy the context before returning.
+ *
+ * \param dpy The display pointer.
+ * \param context The context to add.
+ * \param vendor The vendor that owns the context.
+ * \return \p context on success, or \c NULL on failure.
+ */
+GLXContext __glXDispatchAddContextMapping(Display *dpy, GLXContext context, __GLXvendorInfo *vendor);
+
+/*!
+ * Adds a drawable to libGLX's mapping.
+ *
+ * Note that unlike contexts and configs, failing to add a drawable is not a
+ * problem. libGLX can query the server later to find out which vendor owns the
+ * drawable.
+ *
+ * \param dpy The display pointer.
+ * \param draw The drawable to add.
+ * \param vendor The vendor that owns the drawable.
+ */
+void __glXDispatchAddDrawableMapping(Display *dpy, GLXDrawable draw, __GLXvendorInfo *vendor);
+
+/*!
+ * Adds a GLXFBConfig to libGLX's mapping.
+ *
+ * \param dpy The display pointer.
+ * \param config The config to add.
+ * \param vendor The vendor that owns the config.
+ * \return \p config on success, or \c NULL on failure.
+ */
+GLXFBConfig __glXDispatchAddFBConfigMapping(Display *dpy, GLXFBConfig config, __GLXvendorInfo *vendor);
+
+/*!
+ * Adds an array of GLXFBConfigs to libGLX's mapping.
+ *
+ * If it fails to add any config, then it will free the \p configs array and
+ * set \p nelements to zero before returning.
+ *
+ * \param dpy The display pointer.
+ * \param configs The array of configs to add.
+ * \param nelements A pointer to the number of elements in \p configs.
+ * \param vendor The vendor that owns the configs.
+ * \return \p configs on success, or \c NULL on failure.
+ */
+GLXFBConfig *__glXDispatchAddFBConfigListMapping(Display *dpy, GLXFBConfig *configs, int *nelements, __GLXvendorInfo *vendor);
+
+#endif // GLXDISPATCHSTUBS_H


### PR DESCRIPTION
This adds a Python script to the libglvnd tree that can be used to generate the GLX dispatch stubs for a vendor library.

It's meant to be independent of the rest of libglvnd, so the idea is that you can just copy the files to the vendor library's source tree and use them with little or no modification.

The script reads the Khronos glx.xml file to get most of the function information, and then reads a list of functions from another Python module for everything else. That list module would be specific to each vendor library, since each vendor will typically have a different set of GLX functions.

For each function in the list you need to specify a function name, how the function is dispatched (based on context, drawable, screen number, etc.), and optionally an opcode to use for reporting errors. In most cases, the script can then figure out everything else on its own.

The last commit is the only one that affects the libglvnd build itself. That change makes it use the same script to generate a bunch of the core GLX entrypoints.
