### PR TITLE
OpenGL: Statically export a few more APIs

### DIFF
--- a/src/generate/genCommon.py
+++ b/src/generate/genCommon.py
@@ -41,6 +41,7 @@ _LIBRARY_FEATURE_NAMES = {
         "GL_VERSION_2_0", "GL_VERSION_2_1", "GL_VERSION_3_0", "GL_VERSION_3_1",
         "GL_VERSION_3_2", "GL_VERSION_3_3", "GL_VERSION_4_0", "GL_VERSION_4_1",
         "GL_VERSION_4_2", "GL_VERSION_4_3", "GL_VERSION_4_4", "GL_VERSION_4_5",
+        "GL_ARB_imaging", "GL_ARB_multitexture",
     )),
     "glesv1" : frozenset(("GL_VERSION_ES_CM_1_0", "GL_OES_point_size_array")),
     "glesv2" : frozenset(("GL_ES_VERSION_2_0", "GL_ES_VERSION_3_0",


### PR DESCRIPTION
ARB_multitexture and ARB_imaging have arguably been part of the OpenGL
ABI on Linux. Both are exported statically from Mesa's libGL, and
xserver's GLX assumes this. xserver would like to link against libOpenGL
instead of libGL so as not to drag client-side code into the server, but
the simple attempt to do this fails because libOpenGL does not expose
these APIs.

Signed-off-by: Adam Jackson ajax@redhat.com
