### PR TITLE
EGL: Better wayland detection in eglGetDisplay

### DIFF
--- a/src/EGL/libegl.c
+++ b/src/EGL/libegl.c
@@ -145,22 +145,12 @@ static EGLBoolean _eglPointerIsDereferencable(void *p)
 static EGLBoolean IsWaylandDisplay(void *native_display)
 {
     void *first_pointer = *(void **) native_display;
-    void *waylandClientHandle = NULL;
-    void *waylandClientSymbol = NULL;
+    Dl_info info;
 
-    waylandClientHandle = dlopen("libwayland-client.so.0", RTLD_LOCAL | RTLD_LAZY
-#if defined(HAVE_RTLD_NOLOAD)
-            | RTLD_NOLOAD
-#endif
-            );
-    if (waylandClientHandle == NULL) {
-        return EGL_FALSE;
-    }
+    if (dladdr(first_pointer, &info) == 0)
+	return EGL_FALSE;
 
-    waylandClientSymbol = dlsym(waylandClientHandle, "wl_display_interface");
-    dlclose(waylandClientHandle);
-
-    return (waylandClientSymbol != NULL && waylandClientSymbol == first_pointer);
+    return !strcmp(info.dli_sname, "wl_display_interface");
 }
 
 /*!


### PR DESCRIPTION
The problem with using dlsym to look for wl_display_interface is that
variables by that name are emitted into other client libraries besides
libwayland-client. libSDL2 has this property, at least. Instead of that,
use dladdr() to look up the name of the symbol pointed to, and accept
any symbol with the right name as being wayland enough.

Signed-off-by: Adam Jackson ajax@redhat.com
