### PR TITLE
Fix a crash in process termination when EGL and GLX are both loaded.

### DIFF
--- a/src/EGL/libeglvendor.c
+++ b/src/EGL/libeglvendor.c
@@ -144,6 +144,7 @@ void __eglTeardownVendors(void)
 
     glvnd_list_for_each_entry_safe(vendor, vendorTemp, &__eglVendorList, entry) {
         glvnd_list_del(&vendor->entry);
+        __glDispatchForceUnpatch(vendor->vendorID);
         TeardownVendor(vendor);
     }
 }

--- a/src/GLdispatch/GLdispatch.h
+++ b/src/GLdispatch/GLdispatch.h
@@ -320,4 +320,13 @@ PUBLIC __GLdispatchThreadState *__glDispatchGetCurrentThreadState(void);
  */
 PUBLIC void __glDispatchCheckMultithreaded(void);
 
+/**
+ * Tells libGLdispatch to unpatch the OpenGL entrypoints, but only if they were
+ * patched by the given vendor.
+ *
+ * This is called when libEGL or libGLX is unloaded, to remove any dangling
+ * pointers to the vendor library's patch callbacks.
+ */
+PUBLIC GLboolean __glDispatchForceUnpatch(int vendorID);
+
 #endif

--- a/src/GLdispatch/export_list.sym
+++ b/src/GLdispatch/export_list.sym
@@ -15,3 +15,4 @@ __glDispatchNewVendorID
 __glDispatchRegisterStubCallbacks
 __glDispatchReset
 __glDispatchUnregisterStubCallbacks
+__glDispatchForceUnpatch


### PR DESCRIPTION
Added a new function to libGLdispatch, __glDispatchForceUnpatch, which forces
it to unpatch the OpenGL entrypoints before libEGL or libGLX can unload the
vendor library that patched them.

If a vendor patches the OpenGL entrypoints, libGLdispatch doesn't unpatch them
when that vendor's context is no longer current, because that adds too much
overhead to repeated MakeCurrent+LoseCurrent calls. But, that also means that
the patch callbacks end up being dangling pointers after the vendor library is
unloaded.

This mainly shows up at process termination when a process loads both libEGL
and libGLX, because __glxFini and __eglFini will both call the vendor's
threadAttach callback.

Fixes https://github.com/NVIDIA/libglvnd/issues/103