### PR TITLE
Avoid calling exit in uthash

### DIFF
--- a/include/lkdhash.h
+++ b/include/lkdhash.h
@@ -12,6 +12,13 @@
  */
 
 #include "glvnd_pthread.h"
+
+/*
+ *  Macro to handle uthash_fatal error - Avoid using exit()
+ */
+#include "../src/util/app_error_check.h"
+#define uthash_fatal(msg) glvndAppErrorCheckReportError("Error: %s\n", msg); break
+
 #include "uthash.h"
 
 /*

--- a/src/EGL/Makefile.am
+++ b/src/EGL/Makefile.am
@@ -59,6 +59,7 @@ libEGL_la_CFLAGS += $(PTHREAD_CFLAGS)
 libEGL_la_LIBADD = -ldl
 libEGL_la_LIBADD += -lm
 libEGL_la_LIBADD += $(GL_DISPATCH_DIR)/libGLdispatch.la
+libEGL_la_LIBADD += $(UTIL_DIR)/libapp_error_check.la
 libEGL_la_LIBADD += $(UTIL_DIR)/libtrace.la
 libEGL_la_LIBADD += $(UTIL_DIR)/libglvnd_pthread.la
 libEGL_la_LIBADD += $(UTIL_DIR)/libutils_misc.la


### PR DESCRIPTION
This patch avoid to call exit() in uthash for better error handling

Fix https://github.com/NVIDIA/libglvnd/issues/106
Patch suggested by https://github.com/tbeu

Signed-off-by: Nicolas Chauvet kwizart@gmail.com
