### PR TITLE
Remove the remaining calls to the vendor library from __eglFini and __glXFini.

### DIFF
--- a/src/EGL/libegl.c
+++ b/src/EGL/libegl.c
@@ -1088,7 +1088,7 @@ static void __eglResetOnFork(void);
  * Currently, this only detects whether a fork occurred since the last
  * entrypoint was called, and performs recovery as needed.
  */
-void __eglThreadInitialize(void)
+void CheckFork(void)
 {
     volatile static int g_threadsInCheck = 0;
     volatile static int g_lastPid = -1;
@@ -1120,7 +1120,11 @@ void __eglThreadInitialize(void)
             sched_yield();
         }
     }
+}
 
+void __eglThreadInitialize(void)
+{
+    CheckFork();
     __glDispatchCheckMultithreaded();
 }
 
@@ -1190,7 +1194,7 @@ void _fini(void)
 #endif
 {
     /* Check for a fork before going further. */
-    __eglThreadInitialize();
+    CheckFork();
 
     /*
      * If libEGL owns the current API state, lose current

--- a/src/GLdispatch/GLdispatch.c
+++ b/src/GLdispatch/GLdispatch.c
@@ -570,8 +570,10 @@ static int PatchEntrypoints(
 
     if (stubCurrentPatchCb) {
         // Notify the previous vendor that it no longer owns these
-        // entrypoints.
-        if (stubCurrentPatchCb->releasePatch != NULL) {
+        // entrypoints. If this is being called from a library unload,
+        // though, then skip the callback, because the vendor may have
+        // already been unloaded.
+        if (stubCurrentPatchCb->releasePatch != NULL && !force) {
             stubCurrentPatchCb->releasePatch();
         }
 


### PR DESCRIPTION
Remove the remaining calls to the vendor library from __eglFini and __glXFini.

This removes the call to __glDispatchCheckMultithreaded from __eglFini, so that it doesn't risk calling a vendor library's threadAttach callback after the vendor library is unloaded. GLX had the same fix, but it never got applied to EGL.

I also removed the call to the vendor's releasePatch callback when libGLdispatch is unpatching the entrypoints from __eglFini or __glXFini.
