### PR TITLE
Add configure flags for EGL, GLX, and GLES

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,30 @@ if test "x$ac_cv_prog_cc_c99" = xno; then
         AC_MSG_ERROR([Building libglvnd requires a C99-enabled compiler])
 fi
 
+AC_ARG_ENABLE([egl],
+    [AS_HELP_STRING([--disable-egl],
+        [Disable EGL support @<:@default=enabled@:>@])],
+    [enable_egl="$enableval"],
+    [enable_egl=yes]
+)
+AM_CONDITIONAL([ENABLE_EGL], [test "x$enable_egl" = "xyes"])
+
+AC_ARG_ENABLE([glx],
+    [AS_HELP_STRING([--disable-glx],
+        [Disable GLX support @<:@default=enabled@:>@])],
+    [enable_glx="$enableval"],
+    [enable_glx=yes]
+)
+AM_CONDITIONAL([ENABLE_GLX], [test "x$enable_glx" = "xyes"])
+
+AC_ARG_ENABLE([gles],
+    [AS_HELP_STRING([--disable-gles],
+        [Disable GLES support @<:@default=enabled@:>@])],
+    [enable_gles="$enableval"],
+    [enable_gles=yes]
+)
+AM_CONDITIONAL([ENABLE_GLES], [test "x$enable_gles" = "xyes"])
+
 dnl
 dnl Arch/platform-specific settings. Copied from mesa
 dnl

--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ AM_CONDITIONAL([ENABLE_GLX], [test "x$enable_glx" = "xyes"])
 
 AC_ARG_ENABLE([gles],
     [AS_HELP_STRING([--disable-gles],
-        [Disable GLES support @<:@default=enabled@:>@])],
+        [Do not build the libGLES*.so libraries @<:@default=enabled@:>@])],
     [enable_gles="$enableval"],
     [enable_gles=yes]
 )

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,11 +1,21 @@
-SUBDIRS = util \
-	GLdispatch \
-	EGL \
-	GLX \
-	OpenGL \
-	GLESv1 \
-	GLESv2 \
-	GL
+SUBDIRS =
+SUBDIRS += util
+SUBDIRS += GLdispatch
+SUBDIRS += OpenGL
+
+if ENABLE_EGL
+SUBDIRS += EGL
+endif
+
+if ENABLE_GLX
+SUBDIRS += GLX
+SUBDIRS += GL
+endif
+
+if ENABLE_GLES
+SUBDIRS += GLESv1
+SUBDIRS += GLESv2
+endif
 
 EXTRA_DIST = generate
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -68,12 +68,26 @@ testpatchentrypoints_gldispatch_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
 testpatchentrypoints_gldispatch_LDADD += dummy/libpatchentrypoints.la
 testpatchentrypoints_gldispatch_LDADD += $(top_builddir)/src/util/libutils_misc.la
 
+# Start of GLX-specific tests.
+# Notes that the TESTS_GLX variable must be defined outside the conditional, so
+# that we can include the test scripts in the EXTRA_DIST package. Otherwise,
+# the scripts would be missing when you run "make dist" or "make distcheck".
 
-TESTS += testglxmcbasic.sh
-TESTS += testglxmcloop.sh
-TESTS += testglxmcthreads.sh
-TESTS += testglxmclate.sh
-TESTS += testglxmcoldlink.sh
+TESTS_GLX =
+TESTS_GLX += testglxmcbasic.sh
+TESTS_GLX += testglxmcloop.sh
+TESTS_GLX += testglxmcthreads.sh
+TESTS_GLX += testglxmclate.sh
+TESTS_GLX += testglxmcoldlink.sh
+TESTS_GLX += testglxgetprocaddress.sh
+TESTS_GLX += testglxgetprocaddress_genentry.sh
+TESTS_GLX += testglxgetclientstr.sh
+TESTS_GLX += testglxqueryversion.sh
+TESTS_GLX += testpatchentrypoints.sh
+
+if ENABLE_GLX
+
+TESTS += $(TESTS_GLX)
 
 TESTGLXMAKECURRENT_SOURCES_COMMON = \
 	testglxmakecurrent.c \
@@ -96,14 +110,11 @@ testglxmakecurrent_oldlink_LDADD += $(top_builddir)/src/util/libglvnd_pthread.la
 testglxmakecurrent_oldlink_LDADD += $(top_builddir)/src/util/libtrace.la
 
 
-TESTS += testglxgetprocaddress.sh
-TESTS += testglxgetprocaddress_genentry.sh
 check_PROGRAMS += testglxgetprocaddress
 testglxgetprocaddress_LDADD = -lX11
 testglxgetprocaddress_LDADD += $(top_builddir)/src/GLX/libGLX.la
 
 
-TESTS += testglxgetclientstr.sh
 check_PROGRAMS += testglxgetclientstr
 testglxgetclientstr_LDADD = -lX11
 testglxgetclientstr_LDADD += $(top_builddir)/src/GLX/libGLX.la
@@ -111,14 +122,12 @@ testglxgetclientstr_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
 testglxgetclientstr_LDADD += $(top_builddir)/src/util/libtrace.la
 
 
-TESTS += testglxqueryversion.sh
 check_PROGRAMS += testglxqueryversion
 testglxqueryversion_LDADD = -lX11
 testglxqueryversion_LDADD += $(top_builddir)/src/GLX/libGLX.la
 testglxqueryversion_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
 
 
-TESTS += testpatchentrypoints.sh
 check_PROGRAMS += testpatchentrypoints
 testpatchentrypoints_SOURCES = \
 	testpatchentrypoints.c \
@@ -129,29 +138,41 @@ testpatchentrypoints_LDADD += $(top_builddir)/src/GLX/libGLX.la
 testpatchentrypoints_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
 testpatchentrypoints_LDADD += $(top_builddir)/src/util/libtrace.la
 
+endif # ENABLE_GLX
 
-TESTS += testegldisplay.sh
+
+# Start of EGL-specific tests.
+
+TESTS_EGL =
+TESTS_EGL += testegldisplay.sh
+TESTS_EGL += testegldevice.sh
+TESTS_EGL += testeglgetprocaddress.sh
+TESTS_EGL += testeglmakecurrent.sh
+TESTS_EGL += testeglerror.sh
+TESTS_EGL += testegldebug.sh
+
+if ENABLE_EGL
+
+TESTS += $(TESTS_EGL)
+
 check_PROGRAMS += testegldisplay
 testegldisplay_SOURCES = \
 	testegldisplay.c \
 	egl_test_utils.c
 testegldisplay_LDADD = $(top_builddir)/src/EGL/libEGL.la
 
-TESTS += testegldevice.sh
 check_PROGRAMS += testegldevice
 testegldevice_SOURCES = \
 	testegldevice.c \
 	egl_test_utils.c
 testegldevice_LDADD = $(top_builddir)/src/EGL/libEGL.la
 
-TESTS += testeglgetprocaddress.sh
 check_PROGRAMS += testeglgetprocaddress
 testeglgetprocaddress_SOURCES = \
 	testeglgetprocaddress.c \
 	egl_test_utils.c
 testeglgetprocaddress_LDADD = $(top_builddir)/src/EGL/libEGL.la
 
-TESTS += testeglmakecurrent.sh
 check_PROGRAMS += testeglmakecurrent
 testeglmakecurrent_SOURCES = \
 	testeglmakecurrent.c \
@@ -159,7 +180,6 @@ testeglmakecurrent_SOURCES = \
 testeglmakecurrent_LDADD = $(top_builddir)/src/EGL/libEGL.la
 testeglmakecurrent_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
 
-TESTS += testeglerror.sh
 check_PROGRAMS += testeglerror
 testeglerror_SOURCES = \
 	testeglerror.c \
@@ -168,9 +188,12 @@ testeglerror_LDADD = $(top_builddir)/src/EGL/libEGL.la
 testeglerror_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
 
 
-TESTS += testegldebug.sh
 check_PROGRAMS += testegldebug
 testegldebug_SOURCES = \
 	testegldebug.c \
 	egl_test_utils.c
 testegldebug_LDADD = $(top_builddir)/src/EGL/libEGL.la
+
+endif # ENABLE_EGL
+
+EXTRA_DIST += $(TESTS_GLX) $(TESTS_EGL)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -37,61 +37,15 @@ TESTS_ENVIRONMENT = \
 	TOP_BUILDDIR=$(top_builddir) \
 	ABS_TOP_BUILDDIR=$(abs_top_builddir)
 
-TESTS = \
-	testglxgetprocaddress.sh \
-	testglxgetprocaddress_genentry.sh \
-	testglxmcbasic.sh \
-	testglxmcloop.sh \
-	testglxmcthreads.sh \
-	testglxmclate.sh \
-	testglxmcoldlink.sh \
-	testglxgetclientstr.sh \
-	testglxqueryversion.sh \
-	testpatchentrypoints.sh \
-	testpatchentrypoints_gldispatch.sh \
-	testegldisplay.sh \
-	testegldevice.sh \
-	testeglgetprocaddress.sh \
-	testeglmakecurrent.sh \
-	testeglerror.sh \
-	testegldebug.sh
+TESTS =
+check_PROGRAMS =
 
 EXTRA_DIST = $(TESTS) \
 	glxenv.sh \
 	eglenv.sh \
 	json
 
-check_PROGRAMS = \
-	testglxgetprocaddress \
-	testglxmakecurrent \
-	testglxmakecurrent_oldlink \
-	testglxgetclientstr \
-	testglxqueryversion \
-	testpatchentrypoints \
-	testpatchentrypoints_gldispatch \
-	testegldisplay \
-	testegldevice \
-	testeglgetprocaddress \
-	testeglmakecurrent \
-	testeglerror \
-	testegldebug
-
 # The *_oldlink variant tests that linking against legacy libGL.so works
-
-TESTGLXMAKECURRENT_SOURCES_COMMON = \
-	testglxmakecurrent.c \
-	test_utils.c
-
-testglxmakecurrent_SOURCES = \
-	$(TESTGLXMAKECURRENT_SOURCES_COMMON)
-
-testglxmakecurrent_oldlink_SOURCES = \
-	$(TESTGLXMAKECURRENT_SOURCES_COMMON)
-
-testglxmakecurrent_oldlink_LDADD = -lX11 -ldl
-testglxmakecurrent_oldlink_LDADD += $(top_builddir)/src/GL/libGL.la
-testglxmakecurrent_oldlink_LDADD += $(top_builddir)/src/util/libglvnd_pthread.la
-testglxmakecurrent_oldlink_LDADD += $(top_builddir)/src/util/libtrace.la
 
 # Disable annoying "unused" errors
 AM_CFLAGS =                                  \
@@ -102,33 +56,8 @@ AM_CFLAGS =                                  \
 	-I$(top_srcdir)/src/util/glvnd_pthread
 
 
-testglxgetprocaddress_LDADD = -lX11
-testglxgetprocaddress_LDADD += $(top_builddir)/src/GLX/libGLX.la
-
-testglxmakecurrent_LDADD = -lX11 -ldl
-testglxmakecurrent_LDADD += $(top_builddir)/src/GLX/libGLX.la
-testglxmakecurrent_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
-testglxmakecurrent_LDADD += $(top_builddir)/src/util/libglvnd_pthread.la
-testglxmakecurrent_LDADD += $(top_builddir)/src/util/libtrace.la
-
-testglxgetclientstr_LDADD = -lX11
-testglxgetclientstr_LDADD += $(top_builddir)/src/GLX/libGLX.la
-testglxgetclientstr_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
-testglxgetclientstr_LDADD += $(top_builddir)/src/util/libtrace.la
-
-testglxqueryversion_LDADD = -lX11
-testglxqueryversion_LDADD += $(top_builddir)/src/GLX/libGLX.la
-testglxqueryversion_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
-
-testpatchentrypoints_SOURCES = \
-	testpatchentrypoints.c \
-	test_utils.c
-
-testpatchentrypoints_LDADD = -lX11 -ldl
-testpatchentrypoints_LDADD += $(top_builddir)/src/GLX/libGLX.la
-testpatchentrypoints_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
-testpatchentrypoints_LDADD += $(top_builddir)/src/util/libtrace.la
-
+TESTS += testpatchentrypoints_gldispatch.sh
+check_PROGRAMS += testpatchentrypoints_gldispatch
 testpatchentrypoints_gldispatch_SOURCES = \
 	testpatchentrypoints_gldispatch.c
 testpatchentrypoints_gldispatch_CFLAGS = \
@@ -139,33 +68,108 @@ testpatchentrypoints_gldispatch_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
 testpatchentrypoints_gldispatch_LDADD += dummy/libpatchentrypoints.la
 testpatchentrypoints_gldispatch_LDADD += $(top_builddir)/src/util/libutils_misc.la
 
+
+TESTS += testglxmcbasic.sh
+TESTS += testglxmcloop.sh
+TESTS += testglxmcthreads.sh
+TESTS += testglxmclate.sh
+TESTS += testglxmcoldlink.sh
+
+TESTGLXMAKECURRENT_SOURCES_COMMON = \
+	testglxmakecurrent.c \
+	test_utils.c
+
+check_PROGRAMS += testglxmakecurrent
+testglxmakecurrent_SOURCES = $(TESTGLXMAKECURRENT_SOURCES_COMMON)
+testglxmakecurrent_LDADD = -lX11 -ldl
+testglxmakecurrent_LDADD += $(top_builddir)/src/GLX/libGLX.la
+testglxmakecurrent_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
+testglxmakecurrent_LDADD += $(top_builddir)/src/util/libglvnd_pthread.la
+testglxmakecurrent_LDADD += $(top_builddir)/src/util/libtrace.la
+
+
+check_PROGRAMS += testglxmakecurrent_oldlink
+testglxmakecurrent_oldlink_SOURCES = $(TESTGLXMAKECURRENT_SOURCES_COMMON)
+testglxmakecurrent_oldlink_LDADD = -lX11 -ldl
+testglxmakecurrent_oldlink_LDADD += $(top_builddir)/src/GL/libGL.la
+testglxmakecurrent_oldlink_LDADD += $(top_builddir)/src/util/libglvnd_pthread.la
+testglxmakecurrent_oldlink_LDADD += $(top_builddir)/src/util/libtrace.la
+
+
+TESTS += testglxgetprocaddress.sh
+TESTS += testglxgetprocaddress_genentry.sh
+check_PROGRAMS += testglxgetprocaddress
+testglxgetprocaddress_LDADD = -lX11
+testglxgetprocaddress_LDADD += $(top_builddir)/src/GLX/libGLX.la
+
+
+TESTS += testglxgetclientstr.sh
+check_PROGRAMS += testglxgetclientstr
+testglxgetclientstr_LDADD = -lX11
+testglxgetclientstr_LDADD += $(top_builddir)/src/GLX/libGLX.la
+testglxgetclientstr_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
+testglxgetclientstr_LDADD += $(top_builddir)/src/util/libtrace.la
+
+
+TESTS += testglxqueryversion.sh
+check_PROGRAMS += testglxqueryversion
+testglxqueryversion_LDADD = -lX11
+testglxqueryversion_LDADD += $(top_builddir)/src/GLX/libGLX.la
+testglxqueryversion_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
+
+
+TESTS += testpatchentrypoints.sh
+check_PROGRAMS += testpatchentrypoints
+testpatchentrypoints_SOURCES = \
+	testpatchentrypoints.c \
+	test_utils.c
+
+testpatchentrypoints_LDADD = -lX11 -ldl
+testpatchentrypoints_LDADD += $(top_builddir)/src/GLX/libGLX.la
+testpatchentrypoints_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
+testpatchentrypoints_LDADD += $(top_builddir)/src/util/libtrace.la
+
+
+TESTS += testegldisplay.sh
+check_PROGRAMS += testegldisplay
 testegldisplay_SOURCES = \
 	testegldisplay.c \
 	egl_test_utils.c
 testegldisplay_LDADD = $(top_builddir)/src/EGL/libEGL.la
 
+TESTS += testegldevice.sh
+check_PROGRAMS += testegldevice
 testegldevice_SOURCES = \
 	testegldevice.c \
 	egl_test_utils.c
 testegldevice_LDADD = $(top_builddir)/src/EGL/libEGL.la
 
+TESTS += testeglgetprocaddress.sh
+check_PROGRAMS += testeglgetprocaddress
 testeglgetprocaddress_SOURCES = \
 	testeglgetprocaddress.c \
 	egl_test_utils.c
 testeglgetprocaddress_LDADD = $(top_builddir)/src/EGL/libEGL.la
 
+TESTS += testeglmakecurrent.sh
+check_PROGRAMS += testeglmakecurrent
 testeglmakecurrent_SOURCES = \
 	testeglmakecurrent.c \
 	egl_test_utils.c
 testeglmakecurrent_LDADD = $(top_builddir)/src/EGL/libEGL.la
 testeglmakecurrent_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
 
+TESTS += testeglerror.sh
+check_PROGRAMS += testeglerror
 testeglerror_SOURCES = \
 	testeglerror.c \
 	egl_test_utils.c
 testeglerror_LDADD = $(top_builddir)/src/EGL/libEGL.la
 testeglerror_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
 
+
+TESTS += testegldebug.sh
+check_PROGRAMS += testegldebug
 testegldebug_SOURCES = \
 	testegldebug.c \
 	egl_test_utils.c

--- a/tests/dummy/Makefile.am
+++ b/tests/dummy/Makefile.am
@@ -13,6 +13,7 @@ libpatchentrypoints_la_CFLAGS = \
 libpatchentrypoints_la_SOURCES = \
 	patchentrypoints.c
 
+if ENABLE_GLX
 check_LTLIBRARIES += libGLX_dummy.la
 libGLX_dummy_la_CFLAGS = \
 	-I$(top_srcdir)/src/GLX        \
@@ -29,7 +30,9 @@ libGLX_dummy_la_LIBADD += libpatchentrypoints.la
 libGLX_dummy_la_LDFLAGS = \
 	-shared \
 	-rpath /nowhere
+endif # ENABLE_GLX
 
+if ENABLE_EGL
 EGL_DUMMY_CFLAGS_COMMON = \
 	-I$(top_srcdir)/src/util \
 	-I$(top_srcdir)/include
@@ -56,3 +59,4 @@ libEGL_dummy1_la_SOURCES = $(EGL_DUMMY_SOURCES_COMMON)
 libEGL_dummy1_la_LIBADD = $(EGL_DUMMY_LIBADD_COMMON)
 libEGL_dummy1_la_LDFLAGS = $(EGL_DUMMY_LDFLAGS_COMMON)
 
+endif # ENABLE_EGL

--- a/tests/dummy/Makefile.am
+++ b/tests/dummy/Makefile.am
@@ -3,12 +3,9 @@ noinst_HEADERS = \
 	GLX_dummy.h \
 	EGL_dummy.h
 
-check_LTLIBRARIES = \
-	libpatchentrypoints.la \
-	libGLX_dummy.la \
-	libEGL_dummy0.la \
-	libEGL_dummy1.la
+check_LTLIBRARIES =
  
+check_LTLIBRARIES += libpatchentrypoints.la
 libpatchentrypoints_la_CFLAGS = \
 	-I$(top_srcdir)/src/GLdispatch \
 	-I$(top_srcdir)/src/util       \
@@ -16,6 +13,7 @@ libpatchentrypoints_la_CFLAGS = \
 libpatchentrypoints_la_SOURCES = \
 	patchentrypoints.c
 
+check_LTLIBRARIES += libGLX_dummy.la
 libGLX_dummy_la_CFLAGS = \
 	-I$(top_srcdir)/src/GLX        \
 	-I$(top_srcdir)/src/GLdispatch \
@@ -42,6 +40,7 @@ EGL_DUMMY_LDFLAGS_COMMON = \
 	-shared \
 	-rpath /nowhere
 
+check_LTLIBRARIES += libEGL_dummy0.la
 libEGL_dummy0_la_CFLAGS = \
 	$(EGL_DUMMY_CFLAGS_COMMON) \
 	-D DUMMY_VENDOR_NAME=\"dummy0\"
@@ -49,6 +48,7 @@ libEGL_dummy0_la_SOURCES = $(EGL_DUMMY_SOURCES_COMMON)
 libEGL_dummy0_la_LIBADD = $(EGL_DUMMY_LIBADD_COMMON)
 libEGL_dummy0_la_LDFLAGS = $(EGL_DUMMY_LDFLAGS_COMMON)
 
+check_LTLIBRARIES += libEGL_dummy1.la
 libEGL_dummy1_la_CFLAGS = \
 	$(EGL_DUMMY_CFLAGS_COMMON) \
 	-D DUMMY_VENDOR_NAME=\"dummy1\"


### PR DESCRIPTION
This just adds --disable-egl, --disable-glx, and --disable-gles flags to the configure script, which will tell it not to build libEGL.so, libGLX.so, and libGLES*.so, respectively.