### PR TITLE
Platform GBM support eglGetDisplay

### DIFF
--- a/src/EGL/libegl.c
+++ b/src/EGL/libegl.c
@@ -391,7 +391,7 @@ PUBLIC EGLDisplay EGLAPIENTRY eglGetPlatformDisplay(EGLenum platform, void *nati
         return EGL_NO_DISPLAY;
     }
 
-    return GetPlatformDisplayCommon(platform, native_display, NULL, "eglGetPlatformDisplay");
+    return GetPlatformDisplayCommon(platform, native_display, attrib_list, "eglGetPlatformDisplay");
 }
 
 EGLDisplay EGLAPIENTRY eglGetPlatformDisplayEXT(EGLenum platform, void *native_display, const EGLint *attrib_list)

--- a/src/EGL/libegl.c
+++ b/src/EGL/libegl.c
@@ -102,6 +102,7 @@ static const struct {
    { EGL_PLATFORM_WAYLAND_KHR, "wayland" },
    { EGL_PLATFORM_ANDROID_KHR, "android" },
    { EGL_PLATFORM_GBM_KHR, "gbm" },
+   { EGL_PLATFORM_GBM_KHR, "drm" },
    { EGL_PLATFORM_DEVICE_EXT, "device" },
    { EGL_NONE, NULL }
 };

--- a/src/EGL/libeglvendor.c
+++ b/src/EGL/libeglvendor.c
@@ -369,6 +369,8 @@ static void CheckVendorExtensionString(__EGLvendorInfo *vendor, const char *str)
     static const char NAME_DEVICE_BASE[] = "EGL_EXT_device_base";
     static const char NAME_DEVICE_ENUM[] = "EGL_EXT_device_enumeration";
     static const char NAME_PLATFORM_DEVICE[] = "EGL_EXT_platform_device";
+    static const char NAME_MESA_PLATFORM_GBM[] = "EGL_MESA_platform_gbm";
+    static const char NAME_KHR_PLATFORM_GBM[] = "EGL_KHR_platform_gbm";
     static const char NAME_EXT_PLATFORM_WAYLAND[] = "EGL_EXT_platform_wayland";
     static const char NAME_KHR_PLATFORM_WAYLAND[] = "EGL_KHR_platform_wayland";
     static const char NAME_EXT_PLATFORM_X11[] = "EGL_EXT_platform_x11";
@@ -388,6 +390,13 @@ static void CheckVendorExtensionString(__EGLvendorInfo *vendor, const char *str)
     if (!vendor->supportsPlatformDevice) {
         if (IsTokenInString(str, NAME_PLATFORM_DEVICE, sizeof(NAME_PLATFORM_DEVICE) - 1, " ")) {
             vendor->supportsPlatformDevice = EGL_TRUE;
+        }
+    }
+
+    if (!vendor->supportsPlatformGbm) {
+        if (IsTokenInString(str, NAME_MESA_PLATFORM_GBM, sizeof(NAME_MESA_PLATFORM_GBM) - 1, " ")
+                || IsTokenInString(str, NAME_KHR_PLATFORM_GBM, sizeof(NAME_KHR_PLATFORM_GBM) - 1, " ")) {
+            vendor->supportsPlatformGbm = EGL_TRUE;
         }
     }
 

--- a/src/EGL/libeglvendor.h
+++ b/src/EGL/libeglvendor.h
@@ -31,6 +31,7 @@ struct __EGLvendorInfoRec {
 
     EGLBoolean supportsDevice;
     EGLBoolean supportsPlatformDevice;
+    EGLBoolean supportsPlatformGbm;
     EGLBoolean supportsPlatformX11;
     EGLBoolean supportsPlatformWayland;
 


### PR DESCRIPTION
The title says it all - the series addresses the missing support for GBM in GLVND.

Without it, older X (glamor in particular) and other applications that use eglGetDisplay() fail.

Furthermore due to a typo/thinko in the EGL_PLATFORM strings, one couldn't even force the correct platform. To top it up eglGetPlatformDisplay attrib_list was going to /dev/null.

FWIW the existing dladdr() trick is broken by design, since it will return false-positive even if one is using $plat_a while linking against correct $library_b. But that's topic for another day.