### PR TITLE
EGL: Allow vendor libraries to identify platforms for eglGetDisplay.

### DIFF
--- a/include/glvnd/libeglabi.h
+++ b/include/glvnd/libeglabi.h
@@ -395,12 +395,18 @@ typedef struct __EGLapiImportsRec {
      * to determine which platform to use for a native display handle in
      * eglGetDisplay.
      *
+     * If no vendor library identifies the platform, then libglvnd will fall
+     * back to its own platform detection logic.
+     *
      * Libglvnd can call this function for any native display handle except
      * \c EGL_DEFAULT_DISPLAY.
      *
      * No matter what the value of \p native_display, the vendor library must
      * not crash, and must not return a false match. If the vendor library
      * can't identify the display, then it must return \c EGL_NONE.
+     *
+     * In particular, that means that a vendor library must not return any sort
+     * of default or fallback platform.
      *
      * \param native_display The native display handle passed to eglGetDisplay.
      * \return Either a platform type enum or EGL_NONE.

--- a/include/glvnd/libeglabi.h
+++ b/include/glvnd/libeglabi.h
@@ -86,7 +86,7 @@ extern "C" {
  * will still work.
  */
 #define EGL_VENDOR_ABI_MAJOR_VERSION ((uint32_t) 0)
-#define EGL_VENDOR_ABI_MINOR_VERSION ((uint32_t) 0)
+#define EGL_VENDOR_ABI_MINOR_VERSION ((uint32_t) 1)
 #define EGL_VENDOR_ABI_VERSION ((EGL_VENDOR_ABI_MAJOR_VERSION << 16) | EGL_VENDOR_ABI_MINOR_VERSION)
 static inline uint32_t EGL_VENDOR_ABI_GET_MAJOR_VERSION(uint32_t version)
 {
@@ -388,6 +388,24 @@ typedef struct __EGLapiImportsRec {
      */
     void (*patchThreadAttach)(void);
 
+    /*!
+     * (OPTIONAL) Tries to determine the platform type for a native display.
+     *
+     * If the vendor library provides this function, then libglvnd will call it
+     * to determine which platform to use for a native display handle in
+     * eglGetDisplay.
+     *
+     * Libglvnd can call this function for any native display handle except
+     * \c EGL_DEFAULT_DISPLAY.
+     *
+     * No matter what the value of \p native_display, the vendor library must
+     * not crash, and must not return a false match. If the vendor library
+     * can't identify the display, then it must return \c EGL_NONE.
+     *
+     * \param native_display The native display handle passed to eglGetDisplay.
+     * \return Either a platform type enum or EGL_NONE.
+     */
+    EGLenum (* findNativeDisplayPlatform) (void *native_display);
 } __EGLapiImports;
 
 /*****************************************************************************/

--- a/src/EGL/libegl.c
+++ b/src/EGL/libegl.c
@@ -240,6 +240,16 @@ static EGLenum GuessPlatformType(EGLNativeDisplayType display_id)
         return EGL_PLATFORM_X11_KHR;
     }
 
+    // Lastly, see if any of the vendor libraries can identify the display.
+    glvnd_list_for_each_entry(vendor, vendorList, entry) {
+        if (vendor->eglvc.findNativeDisplayPlatform != NULL) {
+            EGLenum platform = vendor->eglvc.findNativeDisplayPlatform((void *) display_id);
+            if (platform != EGL_NONE) {
+                return platform;
+            }
+        }
+    }
+
     return EGL_NONE;
 };
 

--- a/src/EGL/libegl.c
+++ b/src/EGL/libegl.c
@@ -212,7 +212,17 @@ static EGLenum GuessPlatformType(EGLNativeDisplayType display_id)
     struct glvnd_list *vendorList = __eglLoadVendors();
     __EGLvendorInfo *vendor;
 
-    // First, see if this is a valid EGLDisplayEXT handle.
+    // First, see if any of the vendor libraries can identify the display.
+    glvnd_list_for_each_entry(vendor, vendorList, entry) {
+        if (vendor->eglvc.findNativeDisplayPlatform != NULL) {
+            EGLenum platform = vendor->eglvc.findNativeDisplayPlatform((void *) display_id);
+            if (platform != EGL_NONE) {
+                return platform;
+            }
+        }
+    }
+
+    // Next, see if this is a valid EGLDisplayEXT handle.
     if (__eglGetVendorFromDevice((EGLDeviceEXT) display_id)) {
         return EGL_PLATFORM_DEVICE_EXT;
     }
@@ -238,16 +248,6 @@ static EGLenum GuessPlatformType(EGLNativeDisplayType display_id)
     }
     if (x11Supported && IsX11Display(display_id)) {
         return EGL_PLATFORM_X11_KHR;
-    }
-
-    // Lastly, see if any of the vendor libraries can identify the display.
-    glvnd_list_for_each_entry(vendor, vendorList, entry) {
-        if (vendor->eglvc.findNativeDisplayPlatform != NULL) {
-            EGLenum platform = vendor->eglvc.findNativeDisplayPlatform((void *) display_id);
-            if (platform != EGL_NONE) {
-                return platform;
-            }
-        }
     }
 
     return EGL_NONE;


### PR DESCRIPTION
This is an extension to the EGL vendor library interface that allows vendor libraries to add platform detection for new platforms that libglvnd can't detect on its own.

It adds one new optional function, which takes the display handle passed to eglGetDisplay, and returns a platform enum.

Just calling a vendor's eglGetDisplay implementation directly wouldn't work, because vendor libraries can use things like a fallback platform when it can't otherwise figure it out. In Mesa, for example, if the app passes in something that doesn't look like a Wayland or GBM display, then it would fall back to X11. If it's not an X11 display, then that would prevent any later vendor library from correctly identifying it.

The new function in this change is more constrained, and it keeps a clean separation between platform detection and the resulting eglGetPlatformDisplay call.