### PR TITLE
PPC64LE: Fix the cache clear instructions.

### DIFF
--- a/src/GLdispatch/vnd-glapi/entry_ppc64le_tls.c
+++ b/src/GLdispatch/vnd-glapi/entry_ppc64le_tls.c
@@ -162,7 +162,7 @@ void entry_generate_default_code(char *entry, int slot)
                          "  sync\n\t"
                          "  icbi 0, %0\n\t"
                          "  isync\n"
-                         : "=r" (writeEntry)
+                         : : "r" (writeEntry)
                      );
 }
 

--- a/src/GLdispatch/vnd-glapi/entry_ppc64le_tsd.c
+++ b/src/GLdispatch/vnd-glapi/entry_ppc64le_tsd.c
@@ -210,7 +210,7 @@ void entry_generate_default_code(char *entry, int slot)
                          "  sync\n\t"
                          "  icbi 0, %0\n\t"
                          "  isync\n"
-                         : "=r" (writeEntry)
+                         : : "r" (writeEntry)
                      );
 }
 

--- a/src/util/glvnd_genentry.c
+++ b/src/util/glvnd_genentry.c
@@ -327,7 +327,7 @@ void SetDispatchFuncPointer(GLVNDGenEntrypoint *entry,
                          "  sync\n\t"
                          "  icbi 0, %0\n\t"
                          "  isync\n"
-                         : "=r" (code)
+                         : : "r" (code)
                      );
 #else
 #error "Can't happen -- not implemented"

--- a/tests/dummy/patchentrypoints.c
+++ b/tests/dummy/patchentrypoints.c
@@ -204,7 +204,7 @@ static void patch_ppc64le(char *writeEntry, const char *execEntry,
                          "  sync\n\t"
                          "  icbi 0, %0\n\t"
                          "  isync\n"
-                         : "=r" (writeEntry)
+                         : : "r" (writeEntry)
                      );
 #else
     assert(0); // Should not be calling this


### PR DESCRIPTION
This fixes a crash that shows up in the code generation for PPC64LE dispatch stubs.

The problem was that the __asm__ block was trying to use an output variable instead of an input variable, so it would end up trying to use the wrong address for a couple of the instructions.