### PR TITLE
GL: Use a table to look up core GLX functions.

### DIFF
--- a/src/GL/Makefile.am
+++ b/src/GL/Makefile.am
@@ -32,7 +32,6 @@ MAPI = $(top_srcdir)/$(MAPI_PREFIX)
 GLAPI = $(MAPI)/glapi
 
 noinst_HEADERS =        \
-	libgl.h             \
 	g_glapi_mapi_gl_tmp.h
 
 include $(top_srcdir)/src/GLdispatch/vnd-glapi/entry_files.mk

--- a/src/GL/libgl.c
+++ b/src/GL/libgl.c
@@ -53,9 +53,6 @@ void _init(void)
     // Register these entrypoints with GLdispatch so they can be overwritten at
     // runtime
     patchStubId = __glDispatchRegisterStubCallbacks(stub_get_patch_callbacks());
-
-    // Lookup function pointers from libGLX for the GLX entrypoints
-    __glXWrapperInit();
 }
 
 #if defined(USE_ATTRIBUTE_CONSTRUCTOR)

--- a/src/GL/libgl.c
+++ b/src/GL/libgl.c
@@ -30,7 +30,7 @@
 #include <dlfcn.h>
 #include <GL/gl.h>
 #include <GL/glx.h>
-#include "libgl.h"
+#include "libglxgl.h"
 #include "compiler.h"
 #include "entry.h"
 #include "stub.h"

--- a/src/GL/libgl.h
+++ b/src/GL/libgl.h
@@ -1,8 +1,0 @@
-#ifndef __libgl_h__
-#define __libgl_h__
-
-#include "libglxgl.h"
-
-extern void __glXWrapperInit(void);
-
-#endif

--- a/src/GLX/libglx.c
+++ b/src/GLX/libglx.c
@@ -1783,9 +1783,7 @@ PUBLIC __GLXextFuncPtr __glXGLLoadGLXFunction(const char *name,
 {
     __GLXextFuncPtr func;
 
-    if (mutex != NULL) {
-        __glvndPthreadFuncs.mutex_lock(mutex);
-    }
+    __glvndPthreadFuncs.mutex_lock(mutex);
 
     func = *ptr;
     if (func == NULL) {
@@ -1793,9 +1791,7 @@ PUBLIC __GLXextFuncPtr __glXGLLoadGLXFunction(const char *name,
         *ptr = func;
     }
 
-    if (mutex != NULL) {
-        __glvndPthreadFuncs.mutex_unlock(mutex);
-    }
+    __glvndPthreadFuncs.mutex_unlock(mutex);
     return func;
 }
 
@@ -1974,6 +1970,48 @@ static void __glXResetOnFork(void)
     /* Reset all mapping state */
     __glXMappingTeardown(True);
 }
+
+PUBLIC const __glXGLCoreFunctions __GLXGL_CORE_FUNCTIONS = {
+    glXChooseFBConfig,
+    glXChooseVisual,
+    glXCopyContext,
+    glXCreateContext,
+    glXCreateGLXPixmap,
+    glXCreateNewContext,
+    glXCreatePbuffer,
+    glXCreatePixmap,
+    glXCreateWindow,
+    glXDestroyContext,
+    glXDestroyGLXPixmap,
+    glXDestroyPbuffer,
+    glXDestroyPixmap,
+    glXDestroyWindow,
+    glXGetClientString,
+    glXGetConfig,
+    glXGetCurrentContext,
+    glXGetCurrentDrawable,
+    glXGetCurrentReadDrawable,
+    glXGetFBConfigAttrib,
+    glXGetFBConfigs,
+    glXGetProcAddress,
+    glXGetProcAddressARB,
+    glXGetSelectedEvent,
+    glXGetVisualFromFBConfig,
+    glXIsDirect,
+    glXMakeContextCurrent,
+    glXMakeCurrent,
+    glXQueryContext,
+    glXQueryDrawable,
+    glXQueryExtension,
+    glXQueryExtensionsString,
+    glXQueryServerString,
+    glXQueryVersion,
+    glXSelectEvent,
+    glXSwapBuffers,
+    glXUseXFont,
+    glXWaitGL,
+    glXWaitX,
+};
 
 #if defined(USE_ATTRIBUTE_CONSTRUCTOR)
 void __attribute__ ((constructor)) __glXInit(void)

--- a/src/GLX/libglxgl.h
+++ b/src/GLX/libglxgl.h
@@ -8,6 +8,48 @@
  * Glue header defining the ABI between libGLX and the libGL wrapper library.
  */
 
+typedef struct {
+    GLXFBConfig * (* ptr_glXChooseFBConfig) (Display *dpy, int screen, const int *attrib_list, int *nelements);
+    XVisualInfo * (* ptr_glXChooseVisual) (Display *dpy, int screen, int *attribList);
+    void (* ptr_glXCopyContext) (Display *dpy, GLXContext src, GLXContext dst, unsigned long mask);
+    GLXContext (* ptr_glXCreateContext) (Display *dpy, XVisualInfo *vis, GLXContext shareList, Bool direct);
+    GLXPixmap (* ptr_glXCreateGLXPixmap) (Display *dpy, XVisualInfo *visual, Pixmap pixmap);
+    GLXContext (* ptr_glXCreateNewContext) (Display *dpy, GLXFBConfig config, int render_type, GLXContext share_list, Bool direct);
+    GLXPbuffer (* ptr_glXCreatePbuffer) (Display *dpy, GLXFBConfig config, const int *attrib_list);
+    GLXPixmap (* ptr_glXCreatePixmap) (Display *dpy, GLXFBConfig config, Pixmap pixmap, const int *attrib_list);
+    GLXWindow (* ptr_glXCreateWindow) (Display *dpy, GLXFBConfig config, Window win, const int *attrib_list);
+    void (* ptr_glXDestroyContext) (Display *dpy, GLXContext ctx);
+    void (* ptr_glXDestroyGLXPixmap) (Display *dpy, GLXPixmap pixmap);
+    void (* ptr_glXDestroyPbuffer) (Display *dpy, GLXPbuffer pbuf);
+    void (* ptr_glXDestroyPixmap) (Display *dpy, GLXPixmap pixmap);
+    void (* ptr_glXDestroyWindow) (Display *dpy, GLXWindow win);
+    const char * (* ptr_glXGetClientString) (Display *dpy, int name);
+    int (* ptr_glXGetConfig) (Display *dpy, XVisualInfo *visual, int attrib, int *value);
+    GLXContext (* ptr_glXGetCurrentContext) (void);
+    GLXDrawable (* ptr_glXGetCurrentDrawable) (void);
+    GLXDrawable (* ptr_glXGetCurrentReadDrawable) (void);
+    int (* ptr_glXGetFBConfigAttrib) (Display *dpy, GLXFBConfig config, int attribute, int *value);
+    GLXFBConfig * (* ptr_glXGetFBConfigs) (Display *dpy, int screen, int *nelements);
+    __GLXextFuncPtr (* ptr_glXGetProcAddress) (const GLubyte *procName);
+    __GLXextFuncPtr (* ptr_glXGetProcAddressARB) (const GLubyte *procName);
+    void (* ptr_glXGetSelectedEvent) (Display *dpy, GLXDrawable draw, unsigned long *event_mask);
+    XVisualInfo * (* ptr_glXGetVisualFromFBConfig) (Display *dpy, GLXFBConfig config);
+    Bool (* ptr_glXIsDirect) (Display *dpy, GLXContext ctx);
+    Bool (* ptr_glXMakeContextCurrent) (Display *dpy, GLXDrawable draw, GLXDrawable read, GLXContext ctx);
+    Bool (* ptr_glXMakeCurrent) (Display *dpy, GLXDrawable drawable, GLXContext ctx);
+    int (* ptr_glXQueryContext) (Display *dpy, GLXContext ctx, int attribute, int *value);
+    void (* ptr_glXQueryDrawable) (Display *dpy, GLXDrawable draw, int attribute, unsigned int *value);
+    Bool (* ptr_glXQueryExtension) (Display *dpy, int *errorb, int *event);
+    const char * (* ptr_glXQueryExtensionsString) (Display *dpy, int screen);
+    const char * (* ptr_glXQueryServerString) (Display *dpy, int screen, int name);
+    Bool (* ptr_glXQueryVersion) (Display *dpy, int *maj, int *min);
+    void (* ptr_glXSelectEvent) (Display *dpy, GLXDrawable draw, unsigned long event_mask);
+    void (* ptr_glXSwapBuffers) (Display *dpy, GLXDrawable drawable);
+    void (* ptr_glXUseXFont) (Font font, int first, int count, int list);
+    void (* ptr_glXWaitGL) (void);
+    void (* ptr_glXWaitX) (void);
+} __glXGLCoreFunctions;
+
 /**
  * Called from libGL.so to load a GLX function.
  *
@@ -27,5 +69,7 @@
  * \return A pointer to the requested function.
  */
 extern __GLXextFuncPtr __glXGLLoadGLXFunction(const char *name, __GLXextFuncPtr *ptr, glvnd_mutex_t *mutex);
+
+extern const __glXGLCoreFunctions __GLXGL_CORE_FUNCTIONS;
 
 #endif // !defined(__LIB_GLX_GL_H)

--- a/src/generate/gen_libgl_glxstubs.py
+++ b/src/generate/gen_libgl_glxstubs.py
@@ -125,7 +125,7 @@ def generateLibGLXStubs(functions):
 #include <X11/Xlib.h>
 #include <GL/glx.h>
 #include "compiler.h"
-#include "libgl.h"
+#include "libglxgl.h"
 #include "glvnd_pthread.h"
 
 """.lstrip("\n")

--- a/src/generate/gen_libgl_glxstubs.py
+++ b/src/generate/gen_libgl_glxstubs.py
@@ -84,19 +84,15 @@ _SKIP_GLX_FUNCTIONS = frozenset((
     "glXDestroyGLXVideoSourceSGIX",
 ))
 
-def generateGLXStubFunction(func):
+def generateGLXExtensionStubFunction(func):
     text = ""
     text += "typedef {f.rt} (*fn_{f.name}_ptr)({f.decArgs});\n"
     text += "static fn_{f.name}_ptr __real_{f.name};\n"
-    if (func.name not in _LIBGLX_FUNCTIONS):
-        text += "static glvnd_mutex_t __mutex_{f.name} = GLVND_MUTEX_INITIALIZER;\n"
+    text += "static glvnd_mutex_t __mutex_{f.name} = GLVND_MUTEX_INITIALIZER;\n"
     text += "PUBLIC {f.rt} {f.name}({f.decArgs})\n"
     text += "{{\n"
     text += "    fn_{f.name}_ptr _real = "
-    if (func.name not in _LIBGLX_FUNCTIONS):
-        text += "(fn_{f.name}_ptr) LOAD_GLX_FUNC({f.name});\n"
-    else:
-        text += "__real_{f.name};\n"
+    text += "(fn_{f.name}_ptr) LOAD_GLX_FUNC({f.name});\n"
 
     text += "    if(_real != NULL) {{\n"
     if (func.hasReturn()):
@@ -109,6 +105,16 @@ def generateGLXStubFunction(func):
     text += "}}\n\n"
 
     return text.format(f=func, retVal=getDefaultReturnValue(func))
+
+def generateGLXCoreStubFunction(func):
+    text = "PUBLIC {f.rt} {f.name}({f.decArgs})\n"
+    text += "{{\n"
+    text += "    "
+    if (func.hasReturn()):
+        text += "return "
+    text += "__GLXGL_CORE_FUNCTIONS.ptr_{f.name}({f.callArgs});\n"
+    text += "}}\n\n"
+    return text.format(f=func)
 
 def generateLibGLXStubs(functions):
     text = r"""
@@ -127,15 +133,10 @@ def generateLibGLXStubs(functions):
     text += "#define LOAD_GLX_FUNC(name) __glXGLLoadGLXFunction(#name, (__GLXextFuncPtr *) &__real_##name, &__mutex_##name)\n\n"
 
     for func in functions:
-        text += generateGLXStubFunction(func)
-
-    text += "\n"
-    text += "void __glXWrapperInit(void)\n"
-    text += "{\n"
-    for func in functions:
         if (func.name in _LIBGLX_FUNCTIONS):
-            text += '    __glXGLLoadGLXFunction("{f.name}", (__GLXextFuncPtr *) &__real_{f.name}, NULL);\n'.format(f=func)
-    text += "}\n"
+            text += generateGLXCoreStubFunction(func)
+        else:
+            text += generateGLXExtensionStubFunction(func)
 
     return text
 


### PR DESCRIPTION
This is based on the discussion and observations in #123.

Rather than just optimizing the existing __glXGLLoadGLXFunction code, this change adds a static table with all of the core GLX functions. The wrappers for those function in libGL.so just call through that table.

This removes the overhead of looking up each function by name when libGL.so gets initialized.