### PR TITLE
Don't #define USE_ASM (defined(USE_X86_ASM) || ... )

### DIFF
--- a/src/util/glvnd_genentry.c
+++ b/src/util/glvnd_genentry.c
@@ -37,11 +37,15 @@
 #include <sys/mman.h>
 #include <assert.h>
 
-#define USE_ASM (defined(USE_X86_ASM) ||    \
-                 defined(USE_X86_64_ASM) || \
-                 defined(USE_ARMV7_ASM) ||  \
-                 defined(USE_AARCH64_ASM) || \
-                 defined(USE_PPC64LE_ASM))
+#if defined(USE_X86_ASM) ||    \
+    defined(USE_X86_64_ASM) || \
+    defined(USE_ARMV7_ASM) ||  \
+    defined(USE_AARCH64_ASM) || \
+    defined(USE_PPC64LE_ASM)
+# define USE_ASM 1
+#else
+# define USE_ASM 0
+#endif
 
 #if defined(__GNUC__) && USE_ASM
 


### PR DESCRIPTION
This produces a warning when built with clang:
```
 ../../home/aaron/git/libglvnd/src/util/glvnd_genentry.c:46:26: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
 #if defined(__GNUC__) && USE_ASM
                          ^
 ../../home/aaron/git/libglvnd/src/util/glvnd_genentry.c:40:18: note: expanded from macro 'USE_ASM'
 #define USE_ASM (defined(USE_X86_ASM) ||    \
```
Instead, use the defined(...) conditions to conditionally define USE_ASM to 1 or
0 explicitly.