### PR TITLE
Fix typo in _LIBRARY_FEATURE_NAMES.

### DIFF
--- a/src/generate/genCommon.py
+++ b/src/generate/genCommon.py
@@ -44,7 +44,7 @@ _LIBRARY_FEATURE_NAMES = {
     )),
     "glesv1" : frozenset(("GL_VERSION_ES_CM_1_0", "GL_OES_point_size_array")),
     "glesv2" : frozenset(("GL_ES_VERSION_2_0", "GL_ES_VERSION_3_0",
-            "GL_ES_VERSION_3_1" "GL_ES_VERSION_3_2",
+            "GL_ES_VERSION_3_1", "GL_ES_VERSION_3_2",
     )),
 }
 


### PR DESCRIPTION
The missing comma caused the "GL_ES_VERSION_3_1" and "GL_ES_VERSION_3_2" to
concatenate into non-existing feature name. Symbols from gles 3.1 and 3.2 were
then missing in the generated files.