### PR TITLE
Fix memory leak in LoadVendorsFromConfigDir and __eglMappingInit

### DIFF
--- a/src/EGL/libeglmapping.c
+++ b/src/EGL/libeglmapping.c
@@ -259,6 +259,8 @@ void __eglMappingTeardown(EGLBoolean doReset)
         /* Tear down all hashtables used in this file */
         LKDHASH_TEARDOWN(__EGLdisplayInfoHash,
                          __eglDisplayInfoHash, NULL, NULL, EGL_FALSE);
+
+       __glvndWinsysDispatchCleanup();
     }
 }
 

--- a/src/EGL/libeglvendor.c
+++ b/src/EGL/libeglvendor.c
@@ -121,6 +121,7 @@ void LoadVendorsFromConfigDir(const char *dirName)
         } else {
             fprintf(stderr, "ERROR: Could not allocate vendor library path name\n");
         }
+        free(entries[i]);
     }
 
     free(entries);


### PR DESCRIPTION
The individual entries allocated by scandir need to be freed too.