### PR TITLE
updated README with additional prerequisite dependency dh-autoreconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Building the library
 libglvnd build-depends on libx11, glproto and libxext.
 On Debian and derivatives, run:
 
-    sudo apt-get install libxext-dev libx11-dev x11proto-gl-dev
+    sudo apt-get install libxext-dev libx11-dev x11proto-gl-dev dh-autoreconf
 
 Run `./autogen.sh`, then run `./configure` and `make`.
 


### PR DESCRIPTION
./autogen.sh failed because I did not have autreconf installed on my Ubuntu machine.

I updated the README file to reflect that.