### PR TITLE
Add support for GLX_EXT_no_config_context

### DIFF
--- a/src/GLX/libglx.c
+++ b/src/GLX/libglx.c
@@ -262,6 +262,48 @@ PUBLIC GLXContext glXCreateNewContext(Display *dpy, GLXFBConfig config,
     return context;
 }
 
+static GLXContext glXCreateContextAttribsARB(Display *dpy, GLXFBConfig config,
+        GLXContext share_list, Bool direct, const int *attrib_list)
+{
+    GLXContext context = NULL;
+    __GLXvendorInfo *vendor = NULL;
+
+    if (attrib_list != NULL) {
+        // See if the caller passed in a GLX_SCREEN attribute, and if so, use
+        // that to select a vendor library. This is needed for
+        // GLX_EXT_no_config_context, where we won't have a GLXFBConfig handle.
+        int i;
+        for (i=0; attrib_list[i] != None; i += 2) {
+            if (attrib_list[i] == GLX_SCREEN) {
+                int screen = attrib_list[i + 1];
+                vendor = __glXGetDynDispatch(dpy, screen);
+                if (vendor == NULL) {
+                    __glXSendError(dpy, BadValue, 0,
+                            X_GLXCreateContextAtrribsARB, True);
+                    return None;
+                }
+            }
+        }
+    }
+
+    if (vendor == NULL) {
+        // We didn't get a GLX_SCREEN attribute, so look at the config instead.
+        vendor = CommonDispatchFBConfig(dpy, config, X_GLXCreateContextAtrribsARB);
+    }
+
+    if (vendor != NULL && vendor->staticDispatch.createContextAttribsARB != NULL) {
+        context = vendor->staticDispatch.createContextAttribsARB(dpy, config, share_list, direct, attrib_list);
+        if (context != NULL) {
+            if (__glXAddVendorContextMapping(dpy, context, vendor) != 0) {
+                vendor->staticDispatch.destroyContext(dpy, context);
+                context = NULL;
+            }
+        }
+    }
+
+    return context;
+}
+
 PUBLIC void glXDestroyContext(Display *dpy, GLXContext context)
 {
     __GLXvendorInfo *vendor;
@@ -1680,6 +1722,7 @@ const __GLXlocalDispatchFunction LOCAL_GLX_DISPATCH_FUNCTIONS[] =
 
         LOCAL_FUNC_TABLE_ENTRY(glXImportContextEXT)
         LOCAL_FUNC_TABLE_ENTRY(glXFreeContextEXT)
+        LOCAL_FUNC_TABLE_ENTRY(glXCreateContextAttribsARB)
 #undef LOCAL_FUNC_TABLE_ENTRY
     { NULL, NULL }
 };

--- a/src/GLX/libglxabipriv.h
+++ b/src/GLX/libglxabipriv.h
@@ -171,6 +171,7 @@ typedef struct __GLXdispatchTableStaticRec {
 
     PFNGLXIMPORTCONTEXTEXTPROC importContextEXT;
     PFNGLXFREECONTEXTEXTPROC freeContextEXT;
+    PFNGLXCREATECONTEXTATTRIBSARBPROC createContextAttribsARB;
 } __GLXdispatchTableStatic;
 
 #endif

--- a/src/GLX/libglxmapping.c
+++ b/src/GLX/libglxmapping.c
@@ -370,6 +370,7 @@ static GLboolean LookupVendorEntrypoints(__GLXvendorInfo *vendor)
     } while(0)
     LOADENTRYPOINT(importContextEXT,            "glXImportContextEXT"           );
     LOADENTRYPOINT(freeContextEXT,              "glXFreeContextEXT"             );
+    LOADENTRYPOINT(createContextAttribsARB,     "glXCreateContextAttribsARB"    );
 #undef LOADENTRYPOINT
 
     return GL_TRUE;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -76,6 +76,7 @@ testgldispatch_LDADD += $(top_builddir)/src/util/libutils_misc.la
 # the scripts would be missing when you run "make dist" or "make distcheck".
 
 TESTS_GLX =
+TESTS_GLX += testglxcreatecontext.sh
 TESTS_GLX += testglxmcbasic.sh
 TESTS_GLX += testglxmcloop.sh
 TESTS_GLX += testglxmcthreads.sh
@@ -90,6 +91,15 @@ TESTS_GLX += testpatchentrypoints.sh
 if ENABLE_GLX
 
 TESTS += $(TESTS_GLX)
+
+check_PROGRAMS += testglxcreatecontext
+testglxcreatecontext_LDADD = -lX11
+testglxcreatecontext_LDADD += $(top_builddir)/src/GLX/libGLX.la
+testglxcreatecontext_LDADD += $(top_builddir)/src/OpenGL/libOpenGL.la
+testglxcreatecontext_SOURCES = \
+	testglxcreatecontext.c \
+	test_utils.c
+
 
 TESTGLXMAKECURRENT_SOURCES_COMMON = \
 	testglxmakecurrent.c \

--- a/tests/dummy/GLX_dummy.c
+++ b/tests/dummy/GLX_dummy.c
@@ -407,7 +407,12 @@ static int           dummy_glXQueryContext          (Display *dpy,
                                                  int attribute,
                                                  int *value)
 {
-    return 0;
+    if (attribute == GLX_CONTEX_ATTRIB_DUMMY) {
+        *value = 1;
+        return Success;
+    } else {
+        return GLX_BAD_ATTRIBUTE;
+    }
 }
 
 static void          dummy_glXQueryDrawable         (Display *dpy,

--- a/tests/dummy/GLX_dummy.c
+++ b/tests/dummy/GLX_dummy.c
@@ -58,19 +58,12 @@ typedef struct __GLXcontextRec {
 
 static const int FBCONFIGS_PER_SCREEN = 10;
 
-static GLXContext dummy_glXCreateContextAttribsARB(Display *dpy,
-        GLXFBConfig config, GLXContext share_list, Bool direct,
-        const int *attrib_list);
-static GLXContext dispatch_glXCreateContextAttribsARB(Display *dpy,
-        GLXFBConfig config, GLXContext share_list, Bool direct,
-        const int *attrib_list);
 static void dummy_glXExampleExtensionFunction(Display *dpy, int screen, int *retval);
 static void dispatch_glXExampleExtensionFunction(Display *dpy, int screen, int *retval);
 
 enum
 {
     DI_glXExampleExtensionFunction,
-    DI_glXCreateContextAttribsARB,
     DI_COUNT,
 };
 static struct {
@@ -81,7 +74,6 @@ static struct {
 } glxExtensionProcs[] = {
 #define PROC_ENTRY(name) { #name, dummy_##name, dispatch_##name, -1 }
     PROC_ENTRY(glXExampleExtensionFunction),
-    PROC_ENTRY(glXCreateContextAttribsARB),
 #undef PROC_ENTRY
 };
 
@@ -185,29 +177,6 @@ static GLXContext dummy_glXCreateContextAttribsARB(Display *dpy,
 {
     return CommonCreateContext(dpy, GetScreenFromFBConfig(dpy, config));
 }
-
-static GLXContext dispatch_glXCreateContextAttribsARB(Display *dpy,
-        GLXFBConfig config, GLXContext share_list, Bool direct,
-        const int *attrib_list)
-{
-    PFNGLXCREATECONTEXTATTRIBSARBPROC pCreateContextAttribsARB = NULL;
-    __GLXvendorInfo *vendor = apiExports->vendorFromFBConfig(dpy, config);
-    const int index = glxExtensionProcs[DI_glXCreateContextAttribsARB].index;
-    GLXContext ret = NULL;
-
-    if (vendor != NULL) {
-        pCreateContextAttribsARB = (PFNGLXCREATECONTEXTATTRIBSARBPROC)
-            apiExports->fetchDispatchEntry(vendor, index);
-        if (pCreateContextAttribsARB != NULL) {
-            ret = pCreateContextAttribsARB(dpy, config, share_list, direct, attrib_list);
-            if (ret != NULL) {
-                apiExports->addVendorContextMapping(dpy, ret, vendor);
-            }
-        }
-    }
-    return ret;
-}
-
 
 static GLXPixmap     dummy_glXCreateGLXPixmap       (Display *dpy,
                                                  XVisualInfo *vis,
@@ -580,6 +549,7 @@ static const struct {
     PROC_ENTRY(glXQueryContext),
     PROC_ENTRY(glXQueryDrawable),
     PROC_ENTRY(glXSelectEvent),
+    PROC_ENTRY(glXCreateContextAttribsARB),
 #undef PROC_ENTRY
 };
 

--- a/tests/dummy/GLX_dummy.c
+++ b/tests/dummy/GLX_dummy.c
@@ -175,7 +175,20 @@ static GLXContext dummy_glXCreateContextAttribsARB(Display *dpy,
         GLXFBConfig config, GLXContext share_list, Bool direct,
         const int *attrib_list)
 {
-    return CommonCreateContext(dpy, GetScreenFromFBConfig(dpy, config));
+    int screen = -1;
+    if (config != NULL) {
+        screen = GetScreenFromFBConfig(dpy, config);
+    } else {
+        if (attrib_list != NULL) {
+            int i;
+            for (i=0; attrib_list[i] != None; i += 2) {
+                if (attrib_list[i] == GLX_SCREEN) {
+                    screen = attrib_list[i + 1];
+                }
+            }
+        }
+    }
+    return CommonCreateContext(dpy, screen);
 }
 
 static GLXPixmap     dummy_glXCreateGLXPixmap       (Display *dpy,

--- a/tests/dummy/GLX_dummy.h
+++ b/tests/dummy/GLX_dummy.h
@@ -57,6 +57,14 @@ enum {
     GL_MC_LAST_REQ
 } GLmakeCurrentTestRequest;
 
+/**
+ * This is an attribute to query using glXQueryContext to test dispatching by
+ * GLXContext.
+ *
+ * The dummy vendor library will just return 1 for this attribute.
+ */
+#define GLX_CONTEX_ATTRIB_DUMMY 0x10000
+
 /*
  * glMakeCurrentTestResults(): perform queries on vendor library state.
  *

--- a/tests/dummy/GLX_dummy.h
+++ b/tests/dummy/GLX_dummy.h
@@ -30,7 +30,9 @@
 #ifndef __GLX_MAKECURRENT_H__
 #define __GLX_MAKECURRENT_H__
 
+#include <X11/Xlib.h>
 #include <GL/gl.h>
+#include <GL/glx.h>
 
 /*
  * Contains definition of the fake GL extension functions exported by the
@@ -88,5 +90,15 @@ typedef void (*PFNGLMAKECURRENTTESTRESULTSPROC)(
     GLboolean *saw,
     void **ret
 );
+
+/**
+ * glXCreateContextVendorDUMMY(): Dummy extension function to create a context.
+ *
+ * This tests using a vendor-provided dispach stub to create a context and add
+ * it to GLVND's tracking.
+ */
+typedef GLXContext (* PFNGLXCREATECONTEXTVENDORDUMMYPROC) (Display *dpy,
+        GLXFBConfig config, GLXContext share_list, Bool direct,
+        const int *attrib_list);
 
 #endif

--- a/tests/testglxcreatecontext.c
+++ b/tests/testglxcreatecontext.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2017, NVIDIA CORPORATION.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and/or associated documentation files (the
+ * "Materials"), to deal in the Materials without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Materials, and to
+ * permit persons to whom the Materials are furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * unaltered in all copies or substantial portions of the Materials.
+ * Any additions, deletions, or changes to the original source files
+ * must be clearly indicated in accompanying documentation.
+ *
+ * If only executable code is distributed, then the accompanying
+ * documentation must state that "this software is based in part on the
+ * work of the Khronos Group."
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+ */
+
+/**
+ * \file
+ *
+ * This program tests the various GLX functions to create a context.
+ */
+
+#include <X11/Xlib.h>
+#include <GL/glx.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "test_utils.h"
+#include "dummy/GLX_dummy.h"
+
+static int runTestGLX12(struct window_info *wi);
+static int runTestGLX13(struct window_info *wi);
+static int runTestGLXAttribsConfig(struct window_info *wi);
+static int runTestGLXAttribsScreen(struct window_info *wi);
+static int runTestGLXAttribsVendor(struct window_info *wi);
+static int runTestCommon(struct window_info *wi, GLXContext ctx, const char *testName);
+
+static PFNGLXCREATECONTEXTATTRIBSARBPROC ptr_glXCreateContextAttribsARB;
+static PFNGLXCREATECONTEXTVENDORDUMMYPROC ptr_glXCreateContextVendorDUMMY;
+
+int main(int argc, char **argv)
+{
+    Display *dpy = NULL;
+    struct window_info wi = {};
+    int result = 1;
+
+    dpy = XOpenDisplay(NULL);
+    if (dpy == NULL) {
+        printError("No display! Please re-test with a running X server\n"
+                   "and the DISPLAY environment variable set appropriately.\n");
+        goto done;
+    }
+
+    // Call glXQueryServerString to make libGLX.so load the vendor library for
+    // the screen before we try to load any extension functions.
+    glXQueryServerString(dpy, DefaultScreen(dpy), GLX_EXTENSIONS);
+
+    ptr_glXCreateContextAttribsARB = (PFNGLXCREATECONTEXTATTRIBSARBPROC)
+        glXGetProcAddress((const GLubyte *) "glXCreateContextAttribsARB");
+    if (ptr_glXCreateContextAttribsARB == NULL) {
+        printError("Could not load glXCreateContextAttribsARB\n");
+        goto done;
+    }
+
+    ptr_glXCreateContextVendorDUMMY = (PFNGLXCREATECONTEXTVENDORDUMMYPROC)
+        glXGetProcAddress((const GLubyte *) "glXCreateContextVendorDUMMY");
+    if (ptr_glXCreateContextVendorDUMMY == NULL) {
+        printError("Could not load glXCreateContextVendorDUMMY\n");
+        goto done;
+    }
+
+    if (!testUtilsCreateWindowConfig(dpy, &wi, DefaultScreen(dpy))) {
+        printError("Failed to create window\n");
+        goto done;
+    }
+
+    // Start by testing the core GLX functions, glXCreateContext and
+    // glXCreateNewContext.
+    result = runTestGLX12(&wi);
+    if (result != 0) {
+        goto done;
+    }
+    result = runTestGLX13(&wi);
+    if (result != 0) {
+        goto done;
+    }
+
+    // Next, test using glXCreateContextAttribsARB. This can dispatch one of
+    // two ways. First, test dispatching using a GLXFBConfig handle.
+    result = runTestGLXAttribsConfig(&wi);
+    if (result != 0) {
+        goto done;
+    }
+
+    // Next, test using the GLX_EXT_no_config_context extension. In this case,
+    // we'll pass NULL for the GLXFBConfig parameter, but then specify a screen
+    // number using an attribute.
+    result = runTestGLXAttribsScreen(&wi);
+    if (result != 0) {
+        goto done;
+    }
+
+    // All of the above functions have dispatch stubs in libGLX.so itself, so
+    // test to make sure that a vendor can provide an extension function and
+    // dispatch stub to create a context.
+    result = runTestGLXAttribsVendor(&wi);
+    if (result != 0) {
+        goto done;
+    }
+
+done:
+    if (dpy != NULL) {
+        if (wi.dpy != NULL) {
+            testUtilsDestroyWindow(dpy, &wi);
+        }
+        XCloseDisplay(dpy);
+    }
+    return result;
+}
+
+int runTestGLX12(struct window_info *wi)
+{
+    GLXContext ctx = glXCreateContext(wi->dpy, wi->visinfo, NULL, True);
+    return runTestCommon(wi, ctx, "glXCreateContext");
+}
+
+int runTestGLX13(struct window_info *wi)
+{
+    GLXContext ctx = glXCreateNewContext(wi->dpy, wi->config, GLX_RGBA_TYPE, NULL, True);
+    return runTestCommon(wi, ctx, "glXCreateNewContext");
+}
+
+int runTestGLXAttribsConfig(struct window_info *wi)
+{
+    GLXContext ctx = ptr_glXCreateContextAttribsARB(wi->dpy, wi->config, NULL, True, NULL);
+    return runTestCommon(wi, ctx, "glXCreateContextAttribsARB(config)");
+}
+
+int runTestGLXAttribsScreen(struct window_info *wi)
+{
+    // Create a context using the GLX_EXT_no_config_context extension. In this
+    // case, we pass NULL for the GLXFBConfig parameter, but then specify a
+    // screen number using an attribute.
+    const int attribs[] = {
+        GLX_SCREEN, wi->visinfo->screen,
+        None
+    };
+    GLXContext ctx = ptr_glXCreateContextAttribsARB(wi->dpy, NULL, NULL, True, attribs);
+    return runTestCommon(wi, ctx, "glXCreateContextAttribsARB(screen)");
+}
+
+int runTestGLXAttribsVendor(struct window_info *wi)
+{
+    GLXContext ctx = ptr_glXCreateContextAttribsARB(wi->dpy, wi->config, NULL, True, NULL);
+    return runTestCommon(wi, ctx, "glXCreateContextVendorDUMMY");
+}
+
+int runTestCommon(struct window_info *wi, GLXContext ctx, const char *testName)
+{
+    int value = -1;
+    int ret = 1;
+    if (ctx == NULL) {
+        printError("%s: failed to create context\n", testName);
+        goto done;
+    }
+
+    // Call glXQueryContext to make sure that we can dispatch to this context
+    if (glXQueryContext(wi->dpy, ctx, GLX_CONTEX_ATTRIB_DUMMY, &value) != Success) {
+        printError("%s: glXQueryContext failed\n", testName);
+        goto done;
+    }
+    if (value != 1) {
+        printError("%s: glXQueryContext returned wrong value %d\n", testName, value);
+        goto done;
+    }
+
+    printf("Test succeeded: %s\n", testName);
+    ret = 0;
+
+done:
+    if (ctx != NULL) {
+        glXDestroyContext(wi->dpy, ctx);
+    }
+    return ret;
+}

--- a/tests/testglxcreatecontext.sh
+++ b/tests/testglxcreatecontext.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source $TOP_SRCDIR/tests/glxenv.sh
+
+./testglxcreatecontext


### PR DESCRIPTION
This series adds a dispatch stub for glXCreateContextAttribsARB that can work with the new GLX_EXT_no_config_context extension.

For reference, this is the pull request for the extension spec:
https://github.com/KhronosGroup/OpenGL-Registry/pull/102

Strictly speaking, it isn't necessary to put this in libglvnd, since a vendor can still provide a dispatch stub on its own. And still should, to stay compatible with existing libglvnd versions.

However, if you have multiple vendor libraries loaded, then you could run into problems if the dispatch stub happened to come from a vendor that doesn't support GLX_EXT_no_config_context. Putting a dispatch stub into libglvnd avoids that.

The first commit adds the dispatch stub, and the rest of series are updates to the unit tests to exercise both paths through glXCreateContextAttribsARB and to improve test coverage for context creation in general.