### PR TITLE
Bump the version numbers in the library filenames

### DIFF
--- a/src/EGL/Makefile.am
+++ b/src/EGL/Makefile.am
@@ -66,7 +66,7 @@ libEGL_la_LIBADD += $(UTIL_DIR)/libcJSON.la
 libEGL_la_LIBADD += $(UTIL_DIR)/libwinsys_dispatch.la
 libEGL_la_LIBADD += libEGL_dispatch_stubs.la
 
-libEGL_la_LDFLAGS = -shared -Wl,-Bsymbolic -version-info 1 $(LINKER_FLAG_NO_UNDEFINED)
+libEGL_la_LDFLAGS = -shared -Wl,-Bsymbolic -version-info 2:0:1 $(LINKER_FLAG_NO_UNDEFINED)
 
 libEGL_la_SOURCES = \
 	libegl.c \

--- a/src/GL/Makefile.am
+++ b/src/GL/Makefile.am
@@ -53,7 +53,7 @@ g_libglglxwrapper.c : $(glapi_gen_libglglxstubs_deps)
 libGL_la_CFLAGS = \
 	-I$(top_srcdir)/include
 
-libGL_la_LDFLAGS = -shared -version-info 1 $(LINKER_FLAG_NO_UNDEFINED)
+libGL_la_LDFLAGS = -shared -version-info 8:0:7 $(LINKER_FLAG_NO_UNDEFINED)
 
 AM_CPPFLAGS = \
 	-I$(TOP)/src/GLdispatch/vnd-glapi \

--- a/src/GLESv1/Makefile.am
+++ b/src/GLESv1/Makefile.am
@@ -33,7 +33,7 @@ libGLESv1_CM_la_SOURCES =
 libGLESv1_CM_la_LDFLAGS = -shared \
 	$(LINKER_FLAG_NO_UNDEFINED) \
 	-export-symbols $(builddir)/g_glesv1_exports.sym \
-	-version-info 1
+	-version-info 3:0:2
 
 libGLESv1_CM_la_LIBADD = \
 	../OpenGL/libopengl_main.la \

--- a/src/GLESv2/Makefile.am
+++ b/src/GLESv2/Makefile.am
@@ -33,7 +33,7 @@ libGLESv2_la_SOURCES =
 libGLESv2_la_LDFLAGS = -shared \
 	$(LINKER_FLAG_NO_UNDEFINED) \
 	-export-symbols $(builddir)/g_glesv2_exports.sym \
-	-version-info 2
+	-version-info 3:0:1
 
 libGLESv2_la_LIBADD = \
 	../OpenGL/libopengl_main.la \


### PR DESCRIPTION
If libglvnd is installed onto a system that already has non-libglvnd versions
of any of the OpenGL libraries installed, then ldconfig can get confused about
which files to create symlinks to. At worst, you could end up with a mix of the
libglvnd libraries and leftover non-libglvnd libraries.

To avoid that, bump the version numbers in these filenames:
- libGL.so.1.0.0 -> libGL.so.1.7.0
- libGLESv1_CM.so.1.0.0 -> libGLESv1_CM.1.1.0
- libGLESv2.so.2.0.0 -> libGLESv2.so.2.1.0
- libEGL.so.1.0.0 -> libEGL.so.1.1.0
