### PR TITLE
Always return an error from eglMakeCurrent if the EGLDispaly is invalid

### DIFF
--- a/src/EGL/libegl.c
+++ b/src/EGL/libegl.c
@@ -642,6 +642,15 @@ PUBLIC EGLBoolean EGLAPIENTRY eglMakeCurrent(EGLDisplay dpy,
 
     __eglEntrypointCommon();
 
+    // According to the EGL spec, the display handle must be valid, even if
+    // the context is NULL.
+    newDpy = __eglLookupDisplay(dpy);
+    if (newDpy == NULL) {
+        __eglReportError(EGL_BAD_DISPLAY, "eglMakeCurrent", NULL,
+                "Invalid display %p", dpy);
+        return EGL_FALSE;
+    }
+
     if (context == EGL_NO_CONTEXT && (draw != EGL_NO_SURFACE || read != EGL_NO_SURFACE)) {
         __eglReportError(EGL_BAD_MATCH, "eglMakeCurrent", NULL,
                 "Got an EGLSurface but no EGLContext");
@@ -691,15 +700,8 @@ PUBLIC EGLBoolean EGLAPIENTRY eglMakeCurrent(EGLDisplay dpy,
     }
 
     if (context != EGL_NO_CONTEXT) {
-        newDpy = __eglLookupDisplay(dpy);
-        if (newDpy == NULL) {
-            __eglReportError(EGL_BAD_DISPLAY, "eglMakeCurrent", NULL,
-                    "Invalid display %p", dpy);
-            return EGL_FALSE;
-        }
         newVendor = newDpy->vendor;
     } else {
-        newDpy = NULL;
         newVendor = NULL;
     }
 

--- a/tests/testeglmakecurrent.c
+++ b/tests/testeglmakecurrent.c
@@ -188,7 +188,7 @@ void checkIsCurrent(const TestContextInfo *ci)
 
 void testSwitchContext(const TestContextInfo *oldCi, const TestContextInfo *newCi)
 {
-    EGLDisplay newDpy = (newCi != NULL ? newCi->dpy : EGL_NO_DISPLAY);
+    EGLDisplay newDpy = (newCi != NULL ? newCi->dpy : oldCi->dpy);
     EGLContext newCtx = (newCi != NULL ? newCi->ctx : EGL_NO_CONTEXT);
 
     if (!eglMakeCurrent(newDpy, EGL_NO_SURFACE, EGL_NO_SURFACE, newCtx)) {
@@ -212,7 +212,7 @@ void testSwitchContext(const TestContextInfo *oldCi, const TestContextInfo *newC
 void testSwitchContextFail(const TestContextInfo *oldCi,
         const TestContextInfo *newCi, const TestContextInfo *failCi)
 {
-    EGLDisplay newDpy = (newCi != NULL ? newCi->dpy : EGL_NO_DISPLAY);
+    EGLDisplay newDpy = (newCi != NULL ? newCi->dpy : oldCi->dpy);
     EGLContext newCtx = (newCi != NULL ? newCi->ctx : EGL_NO_CONTEXT);
     EGLint error;
 


### PR DESCRIPTION
This is a fix to make eglMakeCurrent check the EGLDisplay handle unconditionally. Right now, it ignores the display if the context is NULL, since it doesn't need a display in that case. But, the EGL spec says that it should always fail with the error EGL_BAD_DISPLAY if the display is invalid.