### PR TITLE
build: add library flags to pkgconfig

### DIFF
--- a/libglvnd.pc.in
+++ b/libglvnd.pc.in
@@ -1,10 +1,11 @@
 prefix=@prefix@
 includedir=@includedir@
+libdir=@libdir@
 datarootdir=@datarootdir@
 datadir=@datadir@
 
 Name: libglvnd
 Description: Vendor-neutral OpenGL dispatch library vendor interface
 Version: @PACKAGE_VERSION@
-Libs:
+Libs: -L${libdir} -lOpenGL
 Cflags: -I${includedir}


### PR DESCRIPTION
Libdefinition is missing in the pkgconfig output, so applications can't rely on it for linking.