### PR TITLE
Allow state tracking for drivers that invalidate context and surfaces on eglDestroyContext

### DIFF
--- a/include/glvnd/libeglabi.h
+++ b/include/glvnd/libeglabi.h
@@ -412,6 +412,22 @@ typedef struct __EGLapiImportsRec {
      * \return Either a platform type enum or EGL_NONE.
      */
     EGLenum (* findNativeDisplayPlatform) (void *native_display);
+
+    /*!
+     * (OPTIONAL) Checks if the vendor library immediately invalidates a Context
+     * after eglDestryContext has been called on it.
+     * Due to ambiguity in how sections 3.7.4 and 3.2 of the EGL 1.5 spec are
+     * written it appears that some vendor drivers behave differently to eglGetCurrent*
+     * functions after a context has been destroyed.  This differing behaviour breaks
+     * the context state that libglvnd maintains.
+     *
+     * The solution is to let the vendor glvnd implementation note this behaviour
+     * which allows libglvnd to pass these calls back into the binary driver, rather
+     * than reporting the cached state, which is now considered invalid.
+     *
+     * \return Either EGL_TRUE or EGL_FALSE.
+     */
+    EGLBoolean (* invalidateContextOnDestroy) (void);
 } __EGLapiImports;
 
 /*****************************************************************************/

--- a/src/EGL/libeglabipriv.h
+++ b/src/EGL/libeglabipriv.h
@@ -54,6 +54,8 @@ typedef struct __EGLdispatchTableStaticRec {
     EGLBoolean (* destroySurface) (EGLDisplay dpy, EGLSurface surface);
     EGLBoolean (* getConfigAttrib) (EGLDisplay dpy, EGLConfig config, EGLint attribute, EGLint *value);
     EGLBoolean (* getConfigs) (EGLDisplay dpy, EGLConfig *configs, EGLint config_size, EGLint *num_config);
+    EGLContext (* getCurrentContext) (void);
+    EGLSurface (* getCurrentSurface) (EGLint readdraw);
     EGLBoolean (* makeCurrent) (EGLDisplay dpy, EGLSurface draw, EGLSurface read, EGLContext ctx);
     EGLBoolean (* queryContext) (EGLDisplay dpy, EGLContext ctx, EGLint attribute, EGLint *value);
     const char *(* queryString) (EGLDisplay dpy, EGLint name);
@@ -76,9 +78,7 @@ typedef struct __EGLdispatchTableStaticRec {
 
 #if 0
     EGLDisplay (* getCurrentDisplay) (void);
-    EGLSurface (* getCurrentSurface) (EGLint readdraw);
     EGLDisplay (* getDisplay) (EGLNativeDisplayType display_id);
-    EGLContext (* getCurrentContext) (void);
 #endif
 
     // EGL 1.5 functions. A vendor library is not requires to implement these.

--- a/src/EGL/libeglvendor.c
+++ b/src/EGL/libeglvendor.c
@@ -489,6 +489,10 @@ static __EGLvendorInfo *LoadVendor(const char *filename)
         vendor->patchSupported = EGL_TRUE;
     }
 
+    if (vendor->eglvc.invalidateContextOnDestroy != NULL) {
+         vendor->invalidateContextOnDestroy = vendor->eglvc.invalidateContextOnDestroy();
+    }
+
     if (!LookupVendorEntrypoints(vendor)) {
         goto fail;
     }

--- a/src/EGL/libeglvendor.c
+++ b/src/EGL/libeglvendor.c
@@ -220,6 +220,8 @@ static GLboolean LookupVendorEntrypoints(__EGLvendorInfo *vendor)
     LOADENTRYPOINT(swapInterval,                  "eglSwapInterval"                  );
     LOADENTRYPOINT(createPbufferFromClientBuffer, "eglCreatePbufferFromClientBuffer" );
     LOADENTRYPOINT(releaseThread,                 "eglReleaseThread"                 );
+    LOADENTRYPOINT(getCurrentContext,             "eglGetCurrentContext"             );
+    LOADENTRYPOINT(getCurrentSurface,             "eglGetCurrentSurface"             );
     LOADENTRYPOINT(waitClient,                    "eglWaitClient"                    );
     LOADENTRYPOINT(getError,                      "eglGetError"                      );
 #undef LOADENTRYPOINT

--- a/src/EGL/libeglvendor.h
+++ b/src/EGL/libeglvendor.h
@@ -35,6 +35,8 @@ struct __EGLvendorInfoRec {
     EGLBoolean supportsPlatformX11;
     EGLBoolean supportsPlatformWayland;
 
+    EGLBoolean invalidateContextOnDestroy;
+
     struct glvnd_list entry;
 };
 


### PR DESCRIPTION
This is a code jumping off point to further the discussions related to #166  

I believe that tracking the state on eglDestroyContext is the most true to libglvnd standards that we can implement.  This does fix our existing driver issues, while leaving the default codepaths un-altered, except for of course the eglDestroyContext which now is handled by libglvnd rather than being a straight pass through.