### PR TITLE
configure: Recognize the host_cpu value "armv8l"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,7 +122,7 @@ if test "x$enable_asm" = xyes; then
             ;;
         esac
         ;;
-    armv7*l)
+    armv7*l | armv8*l)
         asm_arch=armv7l
         ;;
     aarch64)


### PR DESCRIPTION
It's possible to get a $host_cpu string of either "armv7" or "armv8l" in the configure script if you're building for ARMv7, so the configure script should recognize either of them.