### PR TITLE
libegl.c: Replace False macro with 0

### DIFF
--- a/src/EGL/libegl.c
+++ b/src/EGL/libegl.c
@@ -621,7 +621,7 @@ static EGLBoolean InternalMakeCurrentDispatch(
 
     apiState = __eglCreateAPIState();
     if (apiState == NULL) {
-        return False;
+        return 0; // False
     }
 
     ret = __glDispatchMakeCurrent(


### PR DESCRIPTION
False macro is defined in [Xlib.h](https://gitlab.freedesktop.org/xorg/lib/libx11/blob/master/include/X11/Xlib.h#L85), therefore it is not found when X11
is not used (USE_X11=0).