### PR TITLE
configure: Allow specifying the page size.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -350,6 +350,13 @@ AX_CHECK_LINK_FLAG([-Xlinker --no-undefined],
       [AC_SUBST([LINKER_FLAG_NO_UNDEFINED], ["-Xlinker --no-undefined"])],
       [AC_SUBST([LINKER_FLAG_NO_UNDEFINED], [""])])
 
+AC_ARG_VAR([GLDISPATCH_PAGE_SIZE],
+    [Page size to align static dispatch stubs])
+AS_IF([test "x$GLDISPATCH_PAGE_SIZE" != "x"],
+      [AC_DEFINE_UNQUOTED([GLDISPATCH_PAGE_SIZE], [$GLDISPATCH_PAGE_SIZE],
+      [Page size to align static dispatch stubs.])])
+
+
 dnl default CFLAGS
 CFLAGS="$CFLAGS -Wall -Werror -include config.h -fvisibility=hidden $DEFINES"
 


### PR DESCRIPTION
On aarch64 and ppc64, the static dispatch stubs in libGLdispatch are aligned to a 64K boundary by default, since that's the largest page size that it might have to deal with.

This adds a configure variable that lets you override that if you know you're going to run on a system with smaller pages.