### PR TITLE
Bump gl.pc version to avoid regressing app builds.

### DIFF
--- a/src/GL/gl.pc.in
+++ b/src/GL/gl.pc.in
@@ -5,6 +5,6 @@ includedir=@includedir@
 
 Name: gl
 Description: Legacy OpenGL and GLX library and headers
-Version: 1.2
+Version: 19.2
 Libs: -L${libdir} -lGL
 Cflags: -I${includedir}


### PR DESCRIPTION
We noticed in the X server that with the move of gl.pc from Mesa to
libglvnd, the server no longer built because it was looking for gl.pc >=
9.2.0 (to make sure that there was a new enough Mesa available -- a
Mesa that long predates libglvnd).  To smooth the glvnd transition,
bump this gl.pc to the last released gl.pc so that apps can keep
building.