### PR TITLE
build: Support meson meson-0.49.2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -132,17 +132,18 @@ endif
 
 gl_dispatch_type = 'pure_c'
 if use_asm
+  thread_type = have_tls ? 'tls' : 'tsd'
   if host_machine.cpu_family().startswith('x86')
     gl_dispatch_type = '@0@_@1@'.format(
       host_machine.cpu_family(),
-      have_tls ? 'tls' : 'tsd',
+      thread_type,
     )
   elif host_machine.cpu_family() == 'arm'
     gl_dispatch_type = 'armv7_tsd'
   elif host_machine.cpu_family() == 'aarch64'
     gl_dispatch_type = 'aarch64_tsd'
   elif host_machine.cpu_family() == 'ppc64'
-    gl_dispatch_type = 'ppc64_@0@'.format(have_tls ? 'tls' : 'tsd')
+    gl_dispatch_type = 'ppc64_@0@'.format(thread_type)
   endif
 endif
 message('Using dispatch stub type: @0@'.format(gl_dispatch_type))


### PR DESCRIPTION
Ternary operator inside method call crashes the parser,
so it's relocated outside.

Bug: https://github.com/NVIDIA/libglvnd/issues/198
Forwarded: https://github.com/NVIDIA/libglvnd/pulls
Relate-to: https://github.com/mesonbuild/meson/issues/5003
Signed-off-by: Philippe Coval <rzr@users.sf.net>
Change-Id: I18b6e8eca7564a6a252fff1ec6299311a3a92669