### PR TITLE
Add BTI landing pads for aarch64

### DIFF
--- a/src/GLdispatch/vnd-glapi/entry_aarch64_tsd.c
+++ b/src/GLdispatch/vnd-glapi/entry_aarch64_tsd.c
@@ -55,7 +55,8 @@
     ".balign " U_STRINGIFY(ENTRY_STUB_ALIGN) "\n\t" \
     ".global " func "\n\t"                          \
     ".type " func ", %function\n\t"                 \
-    func ":\n\t"
+    func ":\n\t"                                    \
+    "hint #34\n\t"
 
 /*
  * Looks up the current dispatch table, finds the stub address at the given slot
@@ -69,6 +70,7 @@
  * table then does a branch without link to the function address.
  */
 #define STUB_ASM_CODE(slot)                           \
+    "hint #34\n\t"                                    \
     "stp x1, x0, [sp, #-16]!\n\t"                     \
     "adrp x0, :got:_glapi_Current\n\t"                \
     "ldr x0, [x0, #:got_lo12:_glapi_Current]\n\t"     \


### PR DESCRIPTION
When Branch Target Identifier (BTI) is enabled on aarch64,
any software which run libglvnd will fail with SIGILL, Illegal instruction.
If I run `kmscube` within `gdb`, I get:
```
Thread 1 "kmscube" received signal SIGILL, Illegal instruction.
0x0000fffff7e7e300 in glGetString () from /lib64/libGLESv2.so.2
#0  0x0000fffff7e7e300 in glGetString () from /lib64/libGLESv2.so.2
#1  0x0000aaaaaaaa7b28 in ?? ()
#2  0x0000aaaaaaaa5dc8 [PAC] in ?? ()
#3  0x0000fffff77b70c4 [PAC] in __libc_start_call_main () from /lib64/libc.so.6
#4  0x0000fffff77b7198 [PAC] in __libc_start_main_impl () from /lib64/libc.so.6
#5  0x0000aaaaaaaa75f8 [PAC] in ?? ()
```

This is because some assembler code misses the BTI landing pads.
See: https://developer.arm.com/documentation/102433/0100/Jump-oriented-programming

"hint #34" is the same thing as "BTI C" landing pad, but keep
compatibility with systems without BTI enabled.


